### PR TITLE
Add robots.txt, disallow all

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This pull request adds a [robots.txt](https://www.robotstxt.org/robotstxt.html) that instructs web crawlers not to index the root domain used for CapRover. This change improves privacy for non-public installations of CapRover, and complements the Hidden Root Domain suggestion from the [Best Practices documentation page](https://caprover.com/docs/best-practices.html).