### PR TITLE
Add missing space to text

### DIFF
--- a/src/containers/Dashboard.tsx
+++ b/src/containers/Dashboard.tsx
@@ -405,7 +405,7 @@ export default class Dashboard extends ApiComponent<
                                 <b>
                                     But you still need to assign a domain and
                                     finish the HTTPS setup to fully set up
-                                    CapRover!
+                                    CapRover!{' '}
                                 </b>
                                 You can set up your CapRover instance in two
                                 ways:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36763164/94013250-182b9b00-fdaa-11ea-96db-2ba6e23f3dcf.png)
Fixes the missing space after `to fully set up CapRover!`