### PR TITLE
Sider collapse state persistance

### DIFF
--- a/src/containers/PageRoot.tsx
+++ b/src/containers/PageRoot.tsx
@@ -17,6 +17,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router'
 import ApiManager from '../api/ApiManager'
 import { IVersionInfo } from '../models/IVersionInfo'
 import * as GlobalActions from '../redux/actions/GlobalActions'
+import StorageHelper from '../utils/StorageHelper'
 import AppDetails from './apps/appDetails/AppDetails'
 import Apps from './apps/Apps'
 import OneClickAppSelector from './apps/oneclick/selector/OneClickAppSelector'
@@ -120,6 +121,9 @@ class PageRoot extends ApiComponent<
                 .catch((err) => {
                     // ignore error
                 })
+            this.setState({
+                collapsed: StorageHelper.getSiderCollapsedStateFromLocalStorage(),
+            })
         }
     }
 
@@ -171,6 +175,9 @@ class PageRoot extends ApiComponent<
     }
 
     toggleSider = () => {
+        StorageHelper.setSiderCollapsedStateInLocalStorage(
+            !this.state.collapsed
+        )
         this.setState({ collapsed: !this.state.collapsed })
     }
 

--- a/src/utils/StorageHelper.ts
+++ b/src/utils/StorageHelper.ts
@@ -10,6 +10,7 @@ const sessionStorage = window.sessionStorage
     : fallbackNoOps
 
 const AUTH_KEY = 'CAPROVER_AUTH_KEY'
+const SIDER_COLLAPSED_STATE = 'CAPROVER_SIDER_COLLAPSED_STATE'
 
 class StorageHelper {
     getAuthKeyFromStorage() {
@@ -32,6 +33,18 @@ class StorageHelper {
     setAuthKeyInLocalStorage(authKey: string) {
         localStorage.setItem(AUTH_KEY, authKey)
         sessionStorage.setItem(AUTH_KEY, '')
+    }
+
+    setSiderCollapsedStateInLocalStorage(siderCollapsed: boolean) {
+        localStorage.setItem(
+            SIDER_COLLAPSED_STATE,
+            JSON.stringify(siderCollapsed)
+        )
+    }
+
+    getSiderCollapsedStateFromLocalStorage(): boolean {
+        const storageValue = localStorage.getItem(SIDER_COLLAPSED_STATE)
+        return storageValue ? (JSON.parse(storageValue) as boolean) : true
     }
 }
 

--- a/src/utils/StorageHelper.ts
+++ b/src/utils/StorageHelper.ts
@@ -44,7 +44,7 @@ class StorageHelper {
 
     getSiderCollapsedStateFromLocalStorage(): boolean {
         const storageValue = localStorage.getItem(SIDER_COLLAPSED_STATE)
-        return storageValue ? (JSON.parse(storageValue) as boolean) : true
+        return storageValue && JSON.parse(storageValue)
     }
 }
 


### PR DESCRIPTION
**Description:**
The following change allows persisting the sider collapsed state by storing it within the local storage.  This helps users who prefer a clean user interface from having to minimise the sider after revisiting it.