### PR TITLE
#1021 Fixed: List in Disk cleanup [Dark Theme] - Not display properly while…

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -19,6 +19,7 @@ const darkVars = {
     ...getLessVars('./node_modules/antd/lib/style/themes/dark.less'),
     '@primary-color': defaultVars['@primary-color'],
     '@picker-basic-cell-active-with-range-color': 'darken(@primary-color, 20%)',
+    '@table-selected-row-bg': 'darken(@primary-color, 20%)',
 }
 const lightVars = {
     ...getLessVars('./node_modules/antd/lib/style/themes/compact.less'),


### PR DESCRIPTION
**Situation:**
This PR fixes an issue within the dark mode as mentioned in https://github.com/caprover/caprover/issues/1021.
The issue occurred due to a wrong definition of the colour by antd dark.less. So we override that definition with our own.