### PR TITLE
Add a link to the enviornment variables documentation

### DIFF
--- a/src/containers/apps/appDetails/AppConfigs.tsx
+++ b/src/containers/apps/appDetails/AppConfigs.tsx
@@ -410,7 +410,12 @@ export default class AppConfigs extends Component<
         const app = this.props.apiData!.appDefinition
         return (
             <div>
-                <h4>Environmental Variables:</h4>
+                <h4>
+                    Environmental Variables &nbsp;
+                    <NewTabLink url="https://caprover.com/docs/app-configuration.html#environment-variables">
+                        <InfoCircleOutlined />
+                    </NewTabLink>
+                </h4>
                 <Row align="middle" justify="end">
                     <h5>
                         Bulk Edit&nbsp;{' '}


### PR DESCRIPTION
This link shows up as an "info button" in the same way as currently used by the "Port mapping" section just below. I've added this to make the documentation about the "git sha" (https://github.com/caprover/caprover-website/pull/64) more easily accessible.