### PR TITLE
make app search case insensitive

### DIFF
--- a/src/containers/apps/AppsTable.tsx
+++ b/src/containers/apps/AppsTable.tsx
@@ -177,7 +177,7 @@ class AppsTable extends Component<
                 type="text"
                 onChange={(event) =>
                     self.setState({
-                        searchTerm: (event.target.value || '').trim(),
+                        searchTerm: (event.target.value || '').trim().toLowerCase(),
                     })
                 }
             />


### PR DESCRIPTION
currently caprover does a case sensitive search, it troubles when you are on a mobile device and mobile device keyboards capitalize the first letter by default resulting in no matching apps found
