### PR TITLE
Override checkbox `border-radius` to improve UX, fixes #83

### DIFF
--- a/src/styles/style.less
+++ b/src/styles/style.less
@@ -126,3 +126,10 @@ body {
 .pre-line-content {
     white-space: pre-wrap;
 }
+
+.ant-checkbox {
+    &-inner,
+    &-checked::after {
+        border-radius: 3px;
+    }
+}


### PR DESCRIPTION
This PR overrides the `border-radius` of the checkbox component coming from `antd`. It is currently using `@border-radius-base` that is set to `10px` which is also used by the checkbox component. Unfortunately they do not provide a separate variable to change it only for checkbox.

Fixes #83

<img width="400" alt="Screen Shot 2021-10-12 at 17 16 14" src="https://user-images.githubusercontent.com/920747/136983262-6a1a6d6a-aad8-4955-a3f6-2ebaae3ee3cd.png">
