### PR TITLE
fix: use configured captainSubDomain

### DIFF
--- a/src/containers/Dashboard.tsx
+++ b/src/containers/Dashboard.tsx
@@ -84,7 +84,7 @@ export default class Dashboard extends ApiComponent<
                             onOk() {
                                 if (isUsingHttp) {
                                     window.location.replace(
-                                        `https://captain.${self.state.apiData.rootDomain}`
+                                        `https://${self.state.apiData.captainSubDomain}.${self.state.apiData.rootDomain}`
                                     )
                                 }
                             },
@@ -230,6 +230,8 @@ export default class Dashboard extends ApiComponent<
     }
 
     performUpdateRootDomain(rootDomain: string, force: boolean) {
+        const self = this
+
         this.apiManager
             .updateRootDomain(rootDomain, force)
             .then(function (data: any) {
@@ -244,7 +246,7 @@ export default class Dashboard extends ApiComponent<
                         </div>
                     ),
                     onOk() {
-                        window.location.replace(`http://captain.${rootDomain}`)
+                        window.location.replace(`http://${self.state.apiData.captainSubDomain}.${rootDomain}`)
                     },
                 })
             })

--- a/src/containers/Dashboard.tsx
+++ b/src/containers/Dashboard.tsx
@@ -246,7 +246,9 @@ export default class Dashboard extends ApiComponent<
                         </div>
                     ),
                     onOk() {
-                        window.location.replace(`http://${self.state.apiData.captainSubDomain}.${rootDomain}`)
+                        window.location.replace(
+                            `http://${self.state.apiData.captainSubDomain}.${rootDomain}`
+                        )
                     },
                 })
             })

--- a/src/containers/apps/appDetails/AppDetails.tsx
+++ b/src/containers/apps/appDetails/AppDetails.tsx
@@ -47,6 +47,7 @@ const DEPLOYMENT = 'DEPLOYMENT'
 export interface SingleAppApiData {
     appDefinition: IAppDef
     rootDomain: string
+    captainSubDomain: string
     defaultNginxConfig: string
 }
 
@@ -585,6 +586,7 @@ class AppDetails extends ApiComponent<
                             apiData: {
                                 appDefinition: element,
                                 rootDomain: data.rootDomain,
+                                captainSubDomain: data.captainSubDomain,
                                 defaultNginxConfig: data.defaultNginxConfig,
                             },
                         })

--- a/src/containers/apps/appDetails/deploy/Deployment.tsx
+++ b/src/containers/apps/appDetails/deploy/Deployment.tsx
@@ -127,7 +127,7 @@ export default class Deployment extends ApiComponent<
               }`
             : ''
 
-        const webhookPushUrlFullPath = `${window.location.protocol}//captain.${this.props.apiData.rootDomain}/api/v2${webhookPushUrlRelativePath}`
+        const webhookPushUrlFullPath = `${window.location.protocol}//${this.props.apiData.captainSubDomain}.${this.props.apiData.rootDomain}/api/v2${webhookPushUrlRelativePath}`
 
         return (
             <div>


### PR DESCRIPTION
Use the dynamic captain subdomain (that can be configured via https://github.com/caprover/caprover/commit/7f16a7099bb4c4aac995e5c4ea1470cc53b5a201) instead of hardcoding `captain.${root}` – depends on the related backend PR: https://github.com/caprover/caprover/pull/1330

Tested it locally and it works :)