### PR TITLE
Added separator between methods and made them collapsible

### DIFF
--- a/src/containers/apps/appDetails/deploy/Deployment.tsx
+++ b/src/containers/apps/appDetails/deploy/Deployment.tsx
@@ -1,4 +1,4 @@
-import { RocketOutlined } from '@ant-design/icons'
+import { DownCircleOutlined, RocketOutlined, UpCircleOutlined } from '@ant-design/icons'
 import { Button, Col, Input, message, Row, Tooltip } from 'antd'
 import deepEqual from 'deep-equal'
 import React from 'react'
@@ -6,6 +6,7 @@ import DomUtils from '../../../../utils/DomUtils'
 import Toaster from '../../../../utils/Toaster'
 import Utils from '../../../../utils/Utils'
 import ApiComponent from '../../../global/ApiComponent'
+import ClickableLink from '../../../global/ClickableLink'
 import NewTabLink from '../../../global/NewTabLink'
 import { IAppDef, IAppVersion, RepoInfo } from '../../AppDefinition'
 import { AppDetailsTabProps } from '../AppDetails'
@@ -27,6 +28,12 @@ export default class Deployment extends ApiComponent<
         updatedVersions:
             | { versions: IAppVersion[]; deployedVersion: number }
             | undefined
+        expandedMethod1: boolean
+        expandedMethod2: boolean
+        expandedMethod3: boolean
+        expandedMethod4: boolean
+        expandedMethod5: boolean
+        expandedMethod6: boolean
     }
 > {
     initRepoInfo: RepoInfo
@@ -38,6 +45,12 @@ export default class Deployment extends ApiComponent<
             forceEditableCaptainDefinitionPath: false,
             updatedVersions: undefined,
             buildLogRecreationId: '',
+            expandedMethod1: false,
+            expandedMethod2: false,
+            expandedMethod3: false,
+            expandedMethod4: false,
+            expandedMethod5: false,
+            expandedMethod6: false,
         }
 
         const { appPushWebhook } = props.apiData.appDefinition
@@ -106,6 +119,30 @@ export default class Deployment extends ApiComponent<
             .catch(Toaster.createCatcher())
     }
 
+    onExpandMethodClick(method: number) {
+        switch (method)
+        {
+            case 1:
+                this.setState({ expandedMethod1: !this.state.expandedMethod1 })
+                break;
+            case 2:
+                this.setState({ expandedMethod2: !this.state.expandedMethod2 })
+                break;
+            case 3:
+                this.setState({ expandedMethod3: !this.state.expandedMethod3 })
+                break;
+            case 4:
+                this.setState({ expandedMethod4: !this.state.expandedMethod4 })
+                break;
+            case 5:
+                this.setState({ expandedMethod5: !this.state.expandedMethod5 })
+                break;
+            case 6:
+                this.setState({ expandedMethod6: !this.state.expandedMethod6 })
+                break;
+        }
+    }
+
     render() {
         const self = this
         const app = this.props.apiData.appDefinition
@@ -163,204 +200,346 @@ export default class Deployment extends ApiComponent<
                     appName={app.appName!}
                     key={app.appName! + '-LogsView'}
                 />
-
+                
+                <div style={{ height: 20 }} />
                 <hr />
                 <div style={{ height: 40 }} />
-                <h4>
-                    <RocketOutlined /> Method 1: Official CLI
-                </h4>
-                <p>
-                    Use CLI deploy command. This is the easiest method as it
-                    only requires a simply command like{' '}
-                    <code>caprover deploy</code>. Read more about it in{' '}
-                    <NewTabLink url="https://caprover.com/docs/get-started.html#step-4-deploy-the-test-app">
-                        the docs
-                    </NewTabLink>
-                    . If you're using CI/CD to run <code>caprover deploy</code>{' '}
-                    and you do not wish to use your password, you can use{' '}
-                    <NewTabLink url="https://caprover.com/docs/ci-cd-integration.html#app-tokens">
-                        app-specific tokens
-                    </NewTabLink>
-                    .
-                </p>
-                <Row
-                    justify="start"
-                    style={{ marginTop: this.props.isMobile ? 15 : 0 }}
-                >
-                    <Col flex="0">
-                        <Button
-                            style={{
-                                margin: 5,
-                            }}
-                            block={this.props.isMobile}
-                            onClick={() => {
-                                const newApiData = Utils.copyObject(
-                                    this.props.apiData
-                                )
-                                let tokenConfig =
-                                    newApiData.appDefinition
-                                        .appDeployTokenConfig
-                                if (!tokenConfig) {
-                                    tokenConfig = {
-                                        enabled: false,
+                <ClickableLink
+                        onLinkClicked={() => {
+                            self.onExpandMethodClick(1)
+                        }}
+                    >
+                    
+                    <h4 className="unselectable-span">
+                        {this.state.expandedMethod1 ? (
+                            <UpCircleOutlined />
+                        ) : (
+                            <DownCircleOutlined />
+                        )}
+
+                        <span style={{ marginLeft: 5, marginRight: 5 }}>Method 1: Official CLI</span>
+
+                        <RocketOutlined />
+                    </h4>
+                </ClickableLink>
+                <div  className={
+                            this.state.expandedMethod1
+                                ? ''
+                                : 'hide-on-demand'
+                        }>
+                    <p>
+                        Use CLI deploy command. This is the easiest method as it
+                        only requires a simply command like{' '}
+                        <code>caprover deploy</code>. Read more about it in{' '}
+                        <NewTabLink url="https://caprover.com/docs/get-started.html#step-4-deploy-the-test-app">
+                            the docs
+                        </NewTabLink>
+                        . If you're using CI/CD to run <code>caprover deploy</code>{' '}
+                        and you do not wish to use your password, you can use{' '}
+                        <NewTabLink url="https://caprover.com/docs/ci-cd-integration.html#app-tokens">
+                            app-specific tokens
+                        </NewTabLink>
+                        .
+                    </p>
+                    <Row
+                        justify="start"
+                        style={{ marginTop: this.props.isMobile ? 15 : 0 }}
+                    >
+                        <Col flex="0">
+                            <Button
+                                style={{
+                                    margin: 5,
+                                }}
+                                block={this.props.isMobile}
+                                onClick={() => {
+                                    const newApiData = Utils.copyObject(
+                                        this.props.apiData
+                                    )
+                                    let tokenConfig =
+                                        newApiData.appDefinition
+                                            .appDeployTokenConfig
+                                    if (!tokenConfig) {
+                                        tokenConfig = {
+                                            enabled: false,
+                                        }
                                     }
+                                    tokenConfig.enabled = !tokenConfig.enabled
+                                    newApiData.appDefinition.appDeployTokenConfig =
+                                        tokenConfig
+                                    self.props.updateApiData(newApiData)
+                                    // This is a hack! Find a better way!
+                                    // We need this delay, otherwise the new state will not be used by onUpdateConfigAndSave
+                                    setTimeout(
+                                        self.props.onUpdateConfigAndSave,
+                                        100
+                                    )
+                                }}
+                            >
+                                {app.appDeployTokenConfig?.enabled
+                                    ? 'Disable App Token'
+                                    : 'Enable App Token'}
+                            </Button>
+                        </Col>{' '}
+                        <Col flex="auto">
+                            <Input
+                                onFocus={(e) => {
+                                    if (
+                                        !!app.appDeployTokenConfig?.appDeployToken
+                                    ) {
+                                        e.target.select()
+                                        document.execCommand('copy')
+                                        message.info('Copied to clipboard!')
+                                    }
+                                }}
+                                style={{
+                                    margin: 5,
+                                }}
+                                className="code-input"
+                                readOnly={true}
+                                disabled={!app.appDeployTokenConfig?.appDeployToken}
+                                value={
+                                    app.appDeployTokenConfig?.enabled
+                                        ? app.appDeployTokenConfig?.appDeployToken
+                                        : '** Enable App Token to generate a random app token **'
                                 }
-                                tokenConfig.enabled = !tokenConfig.enabled
-                                newApiData.appDefinition.appDeployTokenConfig =
-                                    tokenConfig
-                                self.props.updateApiData(newApiData)
-                                // This is a hack! Find a better way!
-                                // We need this delay, otherwise the new state will not be used by onUpdateConfigAndSave
-                                setTimeout(
-                                    self.props.onUpdateConfigAndSave,
-                                    100
-                                )
-                            }}
-                        >
-                            {app.appDeployTokenConfig?.enabled
-                                ? 'Disable App Token'
-                                : 'Enable App Token'}
-                        </Button>
-                    </Col>{' '}
-                    <Col flex="auto">
+                            />
+                        </Col>
+                    </Row>
+                </div>
+                <div style={{ height: 20 }} />
+                <hr />
+                <div style={{ height: 20 }} />
+                <ClickableLink
+                        onLinkClicked={() => {
+                            self.onExpandMethodClick(2)
+                        }}
+                    >
+                    
+                    <h4 className="unselectable-span">
+                        {this.state.expandedMethod2 ? (
+                            <UpCircleOutlined />
+                        ) : (
+                            <DownCircleOutlined />
+                        )}
+
+                        <span style={{ marginLeft: 5, marginRight: 5 }}>Method 2: Tarball</span>
+
+                        <RocketOutlined />
+                    </h4>
+                </ClickableLink>
+                <div  className={
+                            this.state.expandedMethod2
+                                ? ''
+                                : 'hide-on-demand'
+                        }>
+                    <p>
+                        You can simply create a tarball (<code>.tar</code>) of your
+                        project and upload it here via upload button.
+                    </p>
+
+                    <TarUploader
+                        onUploadSucceeded={() => self.onUploadSuccess()}
+                        appName={app.appName!}
+                    />
+                </div>
+
+                <div style={{ height: 20 }} />
+                <hr />
+                <div style={{ height: 20 }} />
+                
+                <ClickableLink
+                        onLinkClicked={() => {
+                            self.onExpandMethodClick(3)
+                        }}
+                    >
+                    
+                    <h4 className="unselectable-span">
+                        {this.state.expandedMethod3 || hasPushToken ? (
+                            <UpCircleOutlined />
+                        ) : (
+                            <DownCircleOutlined />
+                        )}
+
+                        <span style={{ marginLeft: 5, marginRight: 5 }}>Method 3: Deploy from Github/Bitbucket/Gitlab</span>
+
+                        <RocketOutlined />
+                    </h4>
+                </ClickableLink>
+                <div  className={
+                            this.state.expandedMethod3 || hasPushToken
+                                ? ''
+                                : 'hide-on-demand'
+                        }>
+                    <p>
+                        Enter your repository information in the form and save. Then
+                        copy the URL in the box as a webhook on Github, Bitbucket,
+                        Gitlab and etc. Once you push a commit, CapRover starts a
+                        new build.
+                        <br />
+                    </p>
+                    <Row>
                         <Input
                             onFocus={(e) => {
-                                if (
-                                    !!app.appDeployTokenConfig?.appDeployToken
-                                ) {
+                                if (hasPushToken) {
                                     e.target.select()
                                     document.execCommand('copy')
                                     message.info('Copied to clipboard!')
                                 }
                             }}
-                            style={{
-                                margin: 5,
-                            }}
                             className="code-input"
                             readOnly={true}
-                            disabled={!app.appDeployTokenConfig?.appDeployToken}
+                            disabled={!hasPushToken}
                             value={
-                                app.appDeployTokenConfig?.enabled
-                                    ? app.appDeployTokenConfig?.appDeployToken
-                                    : '** Enable App Token to generate a random app token **'
+                                hasPushToken
+                                    ? webhookPushUrlFullPath
+                                    : '** Add repo info and save for this webhook to appear **'
                             }
                         />
-                    </Col>
-                </Row>
-                <div style={{ height: 20 }} />
-                <h4>
-                    <RocketOutlined /> Method 2: Tarball
-                </h4>
-                <p>
-                    You can simply create a tarball (<code>.tar</code>) of your
-                    project and upload it here via upload button.
-                </p>
-
-                <TarUploader
-                    onUploadSucceeded={() => self.onUploadSuccess()}
-                    appName={app.appName!}
-                />
-
-                <div style={{ height: 40 }} />
-                <h4>
-                    <RocketOutlined /> Method 3: Deploy from
-                    Github/Bitbucket/Gitlab
-                </h4>
-                <p>
-                    Enter your repository information in the form and save. Then
-                    copy the URL in the box as a webhook on Github, Bitbucket,
-                    Gitlab and etc. Once you push a commit, CapRover starts a
-                    new build.
+                    </Row>
                     <br />
-                </p>
-                <Row>
-                    <Input
-                        onFocus={(e) => {
-                            if (hasPushToken) {
-                                e.target.select()
-                                document.execCommand('copy')
-                                message.info('Copied to clipboard!')
+                    <GitRepoForm
+                        gitRepoValues={repoInfo}
+                        updateRepoInfo={(newRepo) => {
+                            const newApiData = Utils.copyObject(this.props.apiData)
+                            if (newApiData.appDefinition.appPushWebhook) {
+                                newApiData.appDefinition.appPushWebhook.repoInfo =
+                                    Utils.copyObject(newRepo)
+                            } else {
+                                newApiData.appDefinition.appPushWebhook = {
+                                    repoInfo: Utils.copyObject(newRepo),
+                                }
                             }
+                            this.props.updateApiData(newApiData)
                         }}
-                        className="code-input"
-                        readOnly={true}
-                        disabled={!hasPushToken}
-                        value={
-                            hasPushToken
-                                ? webhookPushUrlFullPath
-                                : '** Add repo info and save for this webhook to appear **'
-                        }
                     />
-                </Row>
-                <br />
-                <GitRepoForm
-                    gitRepoValues={repoInfo}
-                    updateRepoInfo={(newRepo) => {
-                        const newApiData = Utils.copyObject(this.props.apiData)
-                        if (newApiData.appDefinition.appPushWebhook) {
-                            newApiData.appDefinition.appPushWebhook.repoInfo =
-                                Utils.copyObject(newRepo)
-                        } else {
-                            newApiData.appDefinition.appPushWebhook = {
-                                repoInfo: Utils.copyObject(newRepo),
-                            }
-                        }
-                        this.props.updateApiData(newApiData)
-                    }}
-                />
-                <Row
-                    justify="end"
-                    style={{ marginTop: this.props.isMobile ? 15 : 0 }}
-                >
-                    <Button
-                        disabled={!hasPushToken}
-                        style={{ marginRight: this.props.isMobile ? 0 : 10 }}
-                        block={this.props.isMobile}
-                        onClick={() => {
-                            self.apiManager
-                                .forceBuild(webhookPushUrlRelativePath)
-                                .then(function () {
-                                    self.onUploadSuccess()
-                                })
-                                .catch(Toaster.createCatcher())
+                    <Row
+                        justify="end"
+                        style={{ marginTop: this.props.isMobile ? 15 : 0 }}
+                    >
+                        <Button
+                            disabled={!hasPushToken}
+                            style={{ marginRight: this.props.isMobile ? 0 : 10 }}
+                            block={this.props.isMobile}
+                            onClick={() => {
+                                self.apiManager
+                                    .forceBuild(webhookPushUrlRelativePath)
+                                    .then(function () {
+                                        self.onUploadSuccess()
+                                    })
+                                    .catch(Toaster.createCatcher())
+                            }}
+                        >
+                            Force Build
+                        </Button>
+                        <Button
+                            disabled={deepEqual(repoInfo, self.initRepoInfo)}
+                            type="primary"
+                            style={{ marginTop: this.props.isMobile ? 15 : 0 }}
+                            block={this.props.isMobile}
+                            onClick={() => self.props.onUpdateConfigAndSave()}
+                        >
+                            Save &amp; Update
+                        </Button>
+                    </Row>
+                </div>
+                <div style={{ height: 20 }} />
+                <hr />
+                <div style={{ height: 20 }} />
+                
+                <ClickableLink
+                        onLinkClicked={() => {
+                            self.onExpandMethodClick(4)
                         }}
                     >
-                        Force Build
-                    </Button>
-                    <Button
-                        disabled={deepEqual(repoInfo, self.initRepoInfo)}
-                        type="primary"
-                        style={{ marginTop: this.props.isMobile ? 15 : 0 }}
-                        block={this.props.isMobile}
-                        onClick={() => self.props.onUpdateConfigAndSave()}
+                    
+                    <h4 className="unselectable-span">
+                        {this.state.expandedMethod4 ? (
+                            <UpCircleOutlined />
+                        ) : (
+                            <DownCircleOutlined />
+                        )}
+
+                        <span style={{ marginLeft: 5, marginRight: 5 }}>Method 4: Deploy plain Dockerfile</span>
+
+                        <RocketOutlined />
+                    </h4>
+                </ClickableLink>
+                <div  className={
+                            this.state.expandedMethod4
+                                ? ''
+                                : 'hide-on-demand'
+                        }>
+                    <UploaderPlainTextDockerfile
+                        appName={app.appName!}
+                        onUploadSucceeded={() => self.onUploadSuccess()}
+                    />
+                </div>
+                <div style={{ height: 20 }} />
+                <hr />
+                <div style={{ height: 20 }} />
+
+                <ClickableLink
+                        onLinkClicked={() => {
+                            self.onExpandMethodClick(5)
+                        }}
                     >
-                        Save &amp; Update
-                    </Button>
-                </Row>
+                    
+                    <h4 className="unselectable-span">
+                        {this.state.expandedMethod5 ? (
+                            <UpCircleOutlined />
+                        ) : (
+                            <DownCircleOutlined />
+                        )}
+
+                        <span style={{ marginLeft: 5, marginRight: 5 }}>Method 5: Deploy captain-definition file</span>
+
+                        <RocketOutlined />
+                    </h4>
+                </ClickableLink>
+                <div  className={
+                            this.state.expandedMethod5
+                                ? ''
+                                : 'hide-on-demand'
+                        }>
+                    <UploaderPlainTextCaptainDefinition
+                        appName={app.appName!}
+                        onUploadSucceeded={() => self.onUploadSuccess()}
+                    />
+                </div>
                 <div style={{ height: 20 }} />
-                <h4>
-                    <RocketOutlined /> Method 4: Deploy plain Dockerfile
-                </h4>
-                <UploaderPlainTextDockerfile
-                    appName={app.appName!}
-                    onUploadSucceeded={() => self.onUploadSuccess()}
-                />
+                <hr />
                 <div style={{ height: 20 }} />
-                <h4>
-                    <RocketOutlined /> Method 5: Deploy captain-definition file
-                </h4>
-                <UploaderPlainTextCaptainDefinition
-                    appName={app.appName!}
-                    onUploadSucceeded={() => self.onUploadSuccess()}
-                />
+
+                <ClickableLink
+                        onLinkClicked={() => {
+                            self.onExpandMethodClick(6)
+                        }}
+                    >
+                    
+                    <h4 className="unselectable-span">
+                        {this.state.expandedMethod6 ? (
+                            <UpCircleOutlined />
+                        ) : (
+                            <DownCircleOutlined />
+                        )}
+
+                        <span style={{ marginLeft: 5, marginRight: 5 }}>Method 6: Deploy via ImageName</span>
+
+                        <RocketOutlined />
+                    </h4>
+                </ClickableLink>
+                <div  className={
+                            this.state.expandedMethod6
+                                ? ''
+                                : 'hide-on-demand'
+                        }>
+                    <UploaderPlainTextImageName
+                        appName={app.appName!}
+                        onUploadSucceeded={() => self.onUploadSuccess()}
+                    />
+                </div>
                 <div style={{ height: 20 }} />
-                <h4>
-                    <RocketOutlined /> Method 6: Deploy via ImageName
-                </h4>
-                <UploaderPlainTextImageName
-                    appName={app.appName!}
-                    onUploadSucceeded={() => self.onUploadSuccess()}
-                />
+                <hr />
                 <div style={{ height: 20 }} />
                 <Row>
                     <Col


### PR DESCRIPTION
Hello, I made the `Apps > Deployment > Methods` view a little bit more readable.
Now all methods are collapsible and when you set and made always-expanded methods that are actually in use.
For example if you set GitHub repository, and then a WebHook is generated, it will remain expanded.

**Everything collapsed:**
![image](https://user-images.githubusercontent.com/38808827/155767644-97696a51-750c-4e6c-8738-36b86965b5f5.png)

**Method 3 is in use:**
![image](https://user-images.githubusercontent.com/38808827/155768149-b62b2ed9-1bb9-4993-8173-cb16c000b72b.png)
