### PR TITLE
Reduce vertical screen estate of "Create New App" on larger screens

### DIFF
--- a/src/containers/apps/CreateNewApp.tsx
+++ b/src/containers/apps/CreateNewApp.tsx
@@ -33,16 +33,16 @@ class CreateNewApp extends Component<
         const self = this
 
         return (
-            <Row justify="center">
-                <Col xs={{ span: 23 }} lg={{ span: 10 }}>
-                    <Card
-                        title={
-                            <span>
-                                <PlusCircleOutlined />
-                                &nbsp;&nbsp;&nbsp;Create A New App
-                            </span>
-                        }
-                    >
+            <Card
+                title={
+                    <span>
+                        <PlusCircleOutlined />
+                        &nbsp;&nbsp;&nbsp;Create A New App
+                    </span>
+                }
+            >
+                <Row justify="center">
+                    <Col lg={{ span: 12 }}>
                         <Row>
                             {self.props.isMobile ? (
                                 <Fragment>
@@ -100,21 +100,17 @@ class CreateNewApp extends Component<
                                 </NewTabLink>
                             </Tooltip>
                         </Row>
-
-                        <br />
-
-                        <hr />
-
-                        <br />
+                    </Col>
+                    <Col lg={{ span: 12 }}>
                         <div style={{ textAlign: 'center' }}>
                             <p>Or Select From</p>
                             <Link to="/apps/oneclick/" className="ant-btn">
                                 One-Click Apps/Databases
                             </Link>
                         </div>
-                    </Card>
-                </Col>
-            </Row>
+                    </Col>
+                </Row>
+            </Card>
         )
     }
 }


### PR DESCRIPTION
Large:
<img width="1019" alt="Screenshot 2023-10-03 at 15 49 02" src="https://github.com/caprover/caprover-frontend/assets/1109982/ae8ce350-84e1-4c55-b28c-a73bb9628e29">

Medium: (padding can be improved)
<img width="685" alt="Screenshot 2023-10-03 at 15 51 21" src="https://github.com/caprover/caprover-frontend/assets/1109982/73d95385-3bf1-45cc-a089-d24782409038">

Small: (padding can be improved)
<img width="533" alt="Screenshot 2023-10-03 at 15 50 06" src="https://github.com/caprover/caprover-frontend/assets/1109982/a021e802-6f2f-40d7-b5a7-371165d2524e">

