### PR TITLE
adding websocket support from one click templates

### DIFF
--- a/src/containers/apps/oneclick/OneClickAppDeploymentHelper.ts
+++ b/src/containers/apps/oneclick/OneClickAppDeploymentHelper.ts
@@ -107,6 +107,12 @@ export default class OneClickAppDeploymentHelper {
                         ) {
                             appDef.notExposeAsWebApp = true
                         }
+                        if (
+                            !!dockerComposeService.caproverExtra
+                                .websocketSupport
+                        ) {
+                            appDef.websocketSupport = true
+                        }
                     }
 
                     return self.apiManager.updateConfigAndSave(appName, appDef)

--- a/src/models/IOneClickAppModels.ts
+++ b/src/models/IOneClickAppModels.ts
@@ -31,6 +31,7 @@ export interface IDockerComposeService {
         dockerfileLines?: string[]
         containerHttpPort: number
         notExposeAsWebApp: boolean // This is actually a string "true", make sure to double negate!
+        websocketSupport: boolean // This is actually a string "true", make sure to double negate!
     }
 }
 


### PR DESCRIPTION
I created an app with the one-click-app database recently and websocket support was not checked by default. This caused the app to not work appropriately until that was enabled. I posted in slack about this and was encouraged to submit a pull request. Please let me know if any adjustments need to be made. 

What I've done here is enabled the front end to pass on a property from a one-click-template for the `websocketSupport` variable.

This will enable one click app templates to automatically have websocket support checked if they so wish. They can just add a property like the following: 

```yml
services:
    $$cap_appname:
        ...

        caproverExtra:
            websocketSupport: 'true'

        ...
```

I tested to ensure this was not a breaking change, and was an opt in only type of feature. From my testing this is friendly to templates with or without the variable.
