### PR TITLE
Fix placeholder value.

### DIFF
--- a/src/containers/apps/oneclick/selector/OneClickReposList.tsx
+++ b/src/containers/apps/oneclick/selector/OneClickReposList.tsx
@@ -121,7 +121,7 @@ export default class OneClickReposList extends ApiComponent<
                 <h4>3rd party repositories:</h4>
                 <div style={{ maxWidth: 600, marginBottom: 30 }}>
                     <Search
-                        placeholder="oneclick-apps.your-3rd-party-domain.com"
+                        placeholder="https://oneclick-apps.your-3rd-party-domain.com"
                         enterButton="Connect New Repository"
                         onSearch={(value) =>
                             self.onConnectNewRepositoryClicked(value)


### PR DESCRIPTION
Adding a 3rd party repository doesn't work without prefixing the domain name with `https://`. I added an `https://` prefix to the placeholder value so a user knows what the expected format is.