### PR TITLE
Tag one click apps with the app name

### DIFF
--- a/src/api/ApiManager.ts
+++ b/src/api/ApiManager.ts
@@ -308,11 +308,17 @@ export default class ApiManager {
             )
     }
 
-    registerNewApp(
-        appName: string,
-        hasPersistentData: boolean,
-        detached: boolean
-    ) {
+    registerNewApp({
+        appName,
+        hasPersistentData,
+        isDetched,
+        tags,
+    }: {
+        appName: string
+        hasPersistentData: boolean
+        isDetched: boolean
+        tags?: string[]
+    }) {
         const http = this.http
 
         return Promise.resolve() //
@@ -320,11 +326,12 @@ export default class ApiManager {
                 http.fetch(
                     http.POST,
                     `/user/apps/appDefinitions/register${
-                        detached ? '?detached=1' : ''
+                        isDetched ? '?detached=1' : ''
                     }`,
                     {
                         appName,
                         hasPersistentData,
+                        tags,
                     }
                 )
             )

--- a/src/containers/apps/Apps.tsx
+++ b/src/containers/apps/Apps.tsx
@@ -34,11 +34,11 @@ export default class Apps extends ApiComponent<
         Promise.resolve() //
             .then(function () {
                 self.setState({ isLoading: true })
-                return self.apiManager.registerNewApp(
+                return self.apiManager.registerNewApp({
                     appName,
                     hasPersistentData,
-                    true
-                )
+                    isDetched: true,
+                })
             })
             .then(function () {
                 return self.reFetchData()

--- a/src/containers/apps/oneclick/OneClickAppDeploymentHelper.ts
+++ b/src/containers/apps/oneclick/OneClickAppDeploymentHelper.ts
@@ -8,18 +8,23 @@ import { IAppDef } from '../AppDefinition'
 export default class OneClickAppDeploymentHelper {
     private apiManager: ApiManager = new ApiManager()
 
-    createRegisterPromise(
-        appName: string,
-        dockerComposeService: IDockerComposeService
-    ) {
+    createRegisterPromise({
+        appName,
+        hasPersistentData,
+        oneClickAppName,
+    }: {
+        appName: string
+        hasPersistentData: boolean
+        oneClickAppName: string
+    }) {
         const self = this
         return Promise.resolve().then(function () {
-            return self.apiManager.registerNewApp(
+            return self.apiManager.registerNewApp({
                 appName,
-                !!dockerComposeService.volumes &&
-                    !!dockerComposeService.volumes.length,
-                false
-            )
+                hasPersistentData,
+                isDetched: false,
+                tags: [oneClickAppName],
+            })
         })
     }
 
@@ -48,6 +53,8 @@ export default class OneClickAppDeploymentHelper {
                     }
 
                     appDef.volumes = appDef.volumes || []
+
+                    console.log('Found these tags', appDef.tags)
 
                     const vols = dockerComposeService.volumes || []
                     for (let i = 0; i < vols.length; i++) {


### PR DESCRIPTION
Sends the user defined Caprover app name as the default tag.

| <img width="869" alt="Screenshot 2023-11-19 at 18 38 43" src="https://github.com/caprover/caprover-frontend/assets/2223680/9c342988-7dcc-4382-86aa-5697992f1d20"> |
| --- |
| Setting the one-click-app name |

| <img width="1004" alt="Screenshot 2023-11-19 at 18 38 31" src="https://github.com/caprover/caprover-frontend/assets/2223680/79d06341-30f3-4e80-9ae0-32e291e99e2e"> |
| --- |
| The tags visible in the list of apps |