### PR TITLE
Adding cap_add ability to caprover through Service Update Override

### DIFF
--- a/src/models/IOneClickAppModels.ts
+++ b/src/models/IOneClickAppModels.ts
@@ -25,6 +25,7 @@ export interface IDockerComposeService {
     environment?: IHashMapGeneric<string>
     depends_on?: string[]
     hostname?: string
+    cap_add?: string[]
 
     // These are CapRover property, not DockerCompose. We use this instead of image if we need to extend the image.
     caproverExtra?: {

--- a/src/utils/DockerComposeToServiceOverride.ts
+++ b/src/utils/DockerComposeToServiceOverride.ts
@@ -19,6 +19,7 @@ export default class DockerComposeToServiceOverride {
     ) {
         const overrides = [] as any[]
         overrides.push(DockerComposeToServiceOverride.parseHostname(compose))
+        overrides.push(DockerComposeToServiceOverride.parseCapAdd(compose))
         // Add more overrides here if needed
 
         let mergedOverride = {} as any
@@ -39,6 +40,22 @@ export default class DockerComposeToServiceOverride {
             override.TaskTemplate = {
                 ContainerSpec: {
                     Hostname: hostname,
+                },
+            }
+        }
+
+        return override
+    }
+
+    private static parseCapAdd(compose: IDockerComposeService) {
+        const override = {} as any
+        if (!!compose.cap_add && Array.isArray(compose.cap_add)) {
+            const capabilityAdd = compose.cap_add
+                .map((cap) => cap.toUpperCase())
+                .map((cap) => (cap.startsWith(`CAP`) ? cap : `CAP_${cap}`))
+            override.TaskTemplate = {
+                ContainerSpec: {
+                    CapabilityAdd: capabilityAdd,
                 },
             }
         }


### PR DESCRIPTION
Adding cap_add to IDockerComposeService
Adding a way to read cap_add from ComposeService using parseCapAdd function


### Most important items

- Make sure to communicate your proposed changes ob our Slack channel beforehand.
- Large PRs (50+ lines of code) will get rejected due to increased difficulty for review - unless they have been communicated beforehand with project maintainers.
- **Refactoring work will get rejected** unless it's been communicated with project's maintainers **beforehand**. There is a thousand ways to write the same code. Every time a code is changed, there is a potential for a new bug. We don't want to refactor the code just for the sake of refactoring.


These rules are strictly enforced to make sure that we can maintain the project moving forward. 
