### PR TITLE
Goaccess fixes for report modal

### DIFF
--- a/src/containers/apps/appDetails/AccessLogReports.tsx
+++ b/src/containers/apps/appDetails/AccessLogReports.tsx
@@ -98,7 +98,7 @@ export default class AccessLogReports extends Component<
                                                 <Button
                                                     onClick={() =>
                                                         this.onReportClick(
-                                                            r.name,
+                                                            this.reportName(r),
                                                             r.url
                                                         )
                                                     }
@@ -178,9 +178,17 @@ export default class AccessLogReports extends Component<
     onReportClick(reportName: string, reportUrl: string) {
         this.setState({ reportOpen: reportName })
 
-        this.props.apiManager.getGoAccessReport(reportUrl).then((report) => {
-            this.setState({ reportHtml: report })
-        })
+        this.props.apiManager
+            .getGoAccessReport(reportUrl)
+            .then((report: string) => {
+                // Add a couple extra override styles to the report to disable the hamburger menu that contains
+                // links which will result in navigating to the caprover dashboard within the iframe
+                report = report.replace(
+                    '</head>',
+                    `<style>.nav-bars{ display: none;} nav .nav-gears{ top: 30px;}</style></head>`
+                )
+                this.setState({ reportHtml: report })
+            })
     }
 
     onModalClose() {


### PR DESCRIPTION
Couple small fixes on the frontend to improve the report modal:
* Update the title to be consistent with the button text
* Hide the menu inside the modal that allows users to navigate to different panes within the report but actually breaks and navigates to the caprover dashboard inside the iframe

First of all, thank you for your contribution! 😄

Please make sure you have read [contribution guidelines](https://github.com/caprover/caprover/blob/master/CONTRIBUTING.md#before-contributing). 



### Most important items

- Make sure to communicate your proposed changes ob our Slack channel beforehand.
- Large PRs (50+ lines of code) will get rejected due to increased difficulty for review - unless they have been communicated beforehand with project maintainers.
- **Refactoring work will get rejected** unless it's been communicated with project's maintainers **beforehand**. There is a thousand ways to write the same code. Every time a code is changed, there is a potential for a new bug. We don't want to refactor the code just for the sake of refactoring.


These rules are strictly enforced to make sure that we can maintain the project moving forward. 
