### PR TITLE
fix: align Themes card width with NGINX Configurations

### DIFF
--- a/src/containers/settings/Settings.tsx
+++ b/src/containers/settings/Settings.tsx
@@ -72,8 +72,8 @@ class Settings extends Component<
                 <Row justify="center" gutter={20}>
                     <Col
                         style={{ marginBottom: 20 }}
-                        lg={{ span: 14 }}
-                        md={{ span: 23 }}
+                        lg={{ span: 18 }}
+                        xs={{ span: 23 }}
                     >
                         <Card
                             style={{ height: '100%' }}


### PR DESCRIPTION
## Summary
- Settings page: Themes card was `lg={{ span: 14 }}` while NGINX Configurations was `lg={{ span: 18 }}`, so Themes looked narrower on desktop.
- Matched Themes to the same column spans (`lg: 18`, `xs: 23`) so both cards align.

## Test plan
- [ ] Open Settings on a wide viewport and confirm Themes and NGINX Configurations cards have the same width.
- [ ] Check mobile width still fills as expected.