### PR TITLE
feat(projects): select parent projects for app deployments

### DIFF
--- a/src/api/ApiManager.test.ts
+++ b/src/api/ApiManager.test.ts
@@ -1,0 +1,78 @@
+import ApiManager from './ApiManager'
+
+describe('ApiManager.startOneClickAppDeploy', () => {
+    it('sends parent and group project options through the generic API', async () => {
+        const apiManager = Object.create(ApiManager.prototype) as ApiManager
+        const executeGenericApiCommand = jest
+            .fn()
+            .mockResolvedValue({ jobId: 'job-id' })
+        const mutableApiManager = apiManager as any
+        mutableApiManager.executeGenericApiCommand = executeGenericApiCommand
+        const template = { services: { web: {} } }
+        const values = [{ key: 'KEY', value: 'value' }]
+
+        await apiManager.startOneClickAppDeploy(template, values, {
+            parentProjectId: ' parent-id ',
+            projectName: ' compose-stack ',
+        })
+
+        expect(executeGenericApiCommand).toHaveBeenCalledWith(
+            'POST',
+            '/user/oneclick/deploy',
+            {
+                template,
+                values,
+                parentProjectId: 'parent-id',
+                projectName: 'compose-stack',
+            }
+        )
+    })
+
+    it('sends an explicit root project for old callers', async () => {
+        const apiManager = Object.create(ApiManager.prototype) as ApiManager
+        const executeGenericApiCommand = jest.fn().mockResolvedValue({
+            jobId: 'job-id',
+        })
+        const mutableApiManager = apiManager as any
+        mutableApiManager.executeGenericApiCommand = executeGenericApiCommand
+
+        await apiManager.startOneClickAppDeploy({}, [])
+
+        expect(executeGenericApiCommand).toHaveBeenCalledWith(
+            'POST',
+            '/user/oneclick/deploy',
+            {
+                template: {},
+                values: [],
+                parentProjectId: '',
+            }
+        )
+    })
+
+    it('accepts positional project options for compatible callers', async () => {
+        const apiManager = Object.create(ApiManager.prototype) as ApiManager
+        const executeGenericApiCommand = jest.fn().mockResolvedValue({
+            jobId: 'job-id',
+        })
+        const mutableApiManager = apiManager as any
+        mutableApiManager.executeGenericApiCommand = executeGenericApiCommand
+
+        await apiManager.startOneClickAppDeploy(
+            {},
+            [],
+            'parent-id',
+            'compose-stack'
+        )
+
+        expect(executeGenericApiCommand).toHaveBeenCalledWith(
+            'POST',
+            '/user/oneclick/deploy',
+            {
+                template: {},
+                values: [],
+                parentProjectId: 'parent-id',
+                projectName: 'compose-stack',
+            }
+        )
+    })
+})

--- a/src/api/ApiManager.ts
+++ b/src/api/ApiManager.ts
@@ -8,6 +8,11 @@ const BASE_DOMAIN = process.env.REACT_APP_API_URL
 const URL = BASE_DOMAIN
 Logger.dev(`API URL: ${URL}`)
 
+export interface OneClickDeploymentOptions {
+    parentProjectId?: string
+    projectName?: string
+}
+
 const authProvider = {
     authToken: '' as string,
     hadEnteredOtp: false as boolean,
@@ -42,6 +47,35 @@ export default class ApiManager extends CapRoverAPI {
 
     getApiBaseUrl() {
         return URL
+    }
+
+    startOneClickAppDeploy(
+        template: any,
+        values?: any,
+        optionsOrParentProjectId: OneClickDeploymentOptions | string = {},
+        projectName?: string
+    ): Promise<{ jobId: string }> {
+        const options: OneClickDeploymentOptions =
+            typeof optionsOrParentProjectId === 'string'
+                ? {
+                      parentProjectId: optionsOrParentProjectId,
+                      projectName,
+                  }
+                : optionsOrParentProjectId || {}
+        const requestBody: any = {
+            template,
+            values,
+            parentProjectId: `${options.parentProjectId || ''}`.trim(),
+        }
+
+        if (options.projectName !== undefined) {
+            requestBody.projectName = `${options.projectName || ''}`.trim()
+        }
+        return this.executeGenericApiCommand(
+            'POST',
+            '/user/oneclick/deploy',
+            requestBody
+        )
     }
 
     static clearAuthKeys() {

--- a/src/components/ParentProjectSelector.test.tsx
+++ b/src/components/ParentProjectSelector.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ParentProjectSelector from './ParentProjectSelector'
+
+jest.mock('../utils/Language', () => ({
+    localize: (key: string, message: string) => message,
+}))
+
+jest.mock('./ProjectSelector', () => (props: any) => (
+    <div>
+        <span data-testid="selected-project">{props.selectedProjectId}</span>
+        <button onClick={() => props.onChange(' project-id ')}>Select</button>
+        <button onClick={() => props.onChange('')}>Clear</button>
+    </div>
+))
+
+const projects = [
+    {
+        id: 'project-id',
+        name: 'project',
+        description: '',
+    },
+]
+
+describe('ParentProjectSelector', () => {
+    it('stays hidden when no projects exist', () => {
+        const { container } = render(
+            <ParentProjectSelector
+                projects={[]}
+                selectedProjectId=""
+                onChange={jest.fn()}
+            />
+        )
+
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('normalizes selection and exposes root through clear', () => {
+        const onChange = jest.fn()
+        render(
+            <ParentProjectSelector
+                projects={projects}
+                selectedProjectId=" project-id "
+                onChange={onChange}
+            />
+        )
+
+        expect(screen.getByTestId('selected-project')).toHaveTextContent(
+            'project-id'
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+        expect(onChange).toHaveBeenNthCalledWith(1, 'project-id')
+        expect(onChange).toHaveBeenNthCalledWith(2, '')
+    })
+})

--- a/src/components/ParentProjectSelector.test.tsx
+++ b/src/components/ParentProjectSelector.test.tsx
@@ -35,6 +35,19 @@ describe('ParentProjectSelector', () => {
         expect(container).toBeEmptyDOMElement()
     })
 
+    it('shows the root selector when explicitly requested without projects', () => {
+        render(
+            <ParentProjectSelector
+                projects={[]}
+                selectedProjectId=""
+                onChange={jest.fn()}
+                hideWhenEmpty={false}
+            />
+        )
+
+        expect(screen.getByTestId('selected-project')).toHaveTextContent('')
+    })
+
     it('normalizes selection and exposes root through clear', () => {
         const onChange = jest.fn()
         render(

--- a/src/components/ParentProjectSelector.tsx
+++ b/src/components/ParentProjectSelector.tsx
@@ -9,13 +9,14 @@ interface ParentProjectSelectorProps {
     onChange: (projectId: string) => void
     excludeProjectId?: string
     style?: CSSProperties
+    hideWhenEmpty?: boolean
 }
 
 export default function ParentProjectSelector(
     props: ParentProjectSelectorProps
 ) {
     const projects = props.projects || []
-    if (projects.length === 0) {
+    if (projects.length === 0 && props.hideWhenEmpty !== false) {
         return <></>
     }
 

--- a/src/components/ParentProjectSelector.tsx
+++ b/src/components/ParentProjectSelector.tsx
@@ -1,0 +1,37 @@
+import { CSSProperties } from 'react'
+import ProjectDefinition from '../models/ProjectDefinition'
+import { localize } from '../utils/Language'
+import ProjectSelector from './ProjectSelector'
+
+interface ParentProjectSelectorProps {
+    projects: ProjectDefinition[]
+    selectedProjectId: string
+    onChange: (projectId: string) => void
+    excludeProjectId?: string
+    style?: CSSProperties
+}
+
+export default function ParentProjectSelector(
+    props: ParentProjectSelectorProps
+) {
+    const projects = props.projects || []
+    if (projects.length === 0) {
+        return <></>
+    }
+
+    return (
+        <div style={props.style}>
+            <div style={{ marginBottom: 5 }}>
+                {localize('apps.parent_project', 'Parent project')}
+            </div>
+            <ProjectSelector
+                allProjects={projects}
+                selectedProjectId={`${props.selectedProjectId || ''}`.trim()}
+                onChange={(value: string) => {
+                    props.onChange(`${value || ''}`.trim())
+                }}
+                excludeProjectId={props.excludeProjectId || 'NONE'}
+            />
+        </div>
+    )
+}

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -46,7 +46,7 @@ class ProjectSelector extends React.Component<ProjectSelectorProps> {
                     return true
                 }
                 // eslint-disable-next-line no-loop-func
-                current = projectsMap[current].parentProjectId
+                current = projectsMap[current]?.parentProjectId
             }
             return false
         }
@@ -85,7 +85,7 @@ class ProjectSelector extends React.Component<ProjectSelectorProps> {
         ]
 
         const handleChange = (value: string) => {
-            onChange(value ?? '')
+            onChange(`${value || ''}`.trim())
         }
 
         return (
@@ -98,7 +98,7 @@ class ProjectSelector extends React.Component<ProjectSelectorProps> {
                     'Select a parent project'
                 )}
                 dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
-                value={selectedProjectId || ''}
+                value={`${selectedProjectId || ''}`.trim()}
                 onChange={handleChange}
                 treeData={root}
             />

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -46,7 +46,7 @@ class ProjectSelector extends React.Component<ProjectSelectorProps> {
                     return true
                 }
                 // eslint-disable-next-line no-loop-func
-                current = projectsMap[current]?.parentProjectId
+                current = projectsMap[current].parentProjectId
             }
             return false
         }
@@ -85,7 +85,7 @@ class ProjectSelector extends React.Component<ProjectSelectorProps> {
         ]
 
         const handleChange = (value: string) => {
-            onChange(`${value || ''}`.trim())
+            onChange(value ?? '')
         }
 
         return (
@@ -98,7 +98,7 @@ class ProjectSelector extends React.Component<ProjectSelectorProps> {
                     'Select a parent project'
                 )}
                 dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
-                value={`${selectedProjectId || ''}`.trim()}
+                value={selectedProjectId || ''}
                 onChange={handleChange}
                 treeData={root}
             />

--- a/src/containers/apps/CreateNewApp.test.tsx
+++ b/src/containers/apps/CreateNewApp.test.tsx
@@ -42,4 +42,10 @@ describe('CreateNewApp project assignment', () => {
             false
         )
     })
+
+    it('keeps the apps home selector hidden when no projects exist', () => {
+        const component = new CreateNewApp(createProps() as any)
+
+        expect(component.createProjectInApp()).toBeUndefined()
+    })
 })

--- a/src/containers/apps/CreateNewApp.test.tsx
+++ b/src/containers/apps/CreateNewApp.test.tsx
@@ -1,0 +1,45 @@
+import { CreateNewApp } from './CreateNewApp'
+
+jest.mock('../../utils/Language', () => ({
+    localize: (key: string, message: string) => message,
+}))
+
+describe('CreateNewApp project assignment', () => {
+    const createProps = () => ({
+        isMobile: true,
+        projects: [],
+        onCreateNewAppClicked: jest.fn(),
+        onOneClickAppClicked: jest.fn(),
+        onDockerComposeClicked: jest.fn(),
+    })
+
+    it('defaults to root, sends a selection, and supports clearing it', () => {
+        const props = createProps()
+        const component = new CreateNewApp(props as any)
+        const mutableState = component.state as any
+        mutableState.appName = 'test-app'
+
+        component.onCreateNewAppClicked()
+        expect(props.onCreateNewAppClicked).toHaveBeenLastCalledWith(
+            'test-app',
+            '',
+            false
+        )
+
+        mutableState.selectedProjectId = 'project-id'
+        component.onCreateNewAppClicked()
+        expect(props.onCreateNewAppClicked).toHaveBeenLastCalledWith(
+            'test-app',
+            'project-id',
+            false
+        )
+
+        mutableState.selectedProjectId = ''
+        component.onCreateNewAppClicked()
+        expect(props.onCreateNewAppClicked).toHaveBeenLastCalledWith(
+            'test-app',
+            '',
+            false
+        )
+    })
+})

--- a/src/containers/apps/CreateNewApp.tsx
+++ b/src/containers/apps/CreateNewApp.tsx
@@ -2,7 +2,7 @@ import { PlusCircleOutlined, QuestionCircleFilled } from '@ant-design/icons'
 import { Button, Card, Checkbox, Col, Input, Row, Tooltip } from 'antd'
 import { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import ParentProjectSelector from '../../components/ParentProjectSelector'
+import ProjectSelector from '../../components/ProjectSelector'
 import { IMobileComponent } from '../../models/ContainerProps'
 import ProjectDefinition from '../../models/ProjectDefinition'
 import { localize } from '../../utils/Language'
@@ -212,16 +212,31 @@ export class CreateNewApp extends Component<
     createProjectInApp() {
         const self = this
 
+        if ((self.props.projects || []).length === 0) {
+            return undefined
+        }
+
         return (
-            <ParentProjectSelector
-                projects={self.props.projects}
-                selectedProjectId={self.state.selectedProjectId}
-                onChange={(value: string) => {
-                    self.setState({
-                        selectedProjectId: value,
-                    })
-                }}
-            />
+            <div>
+                {' '}
+                <div
+                    style={{
+                        marginBottom: 5,
+                    }}
+                >
+                    {localize('apps.parent_project', 'Parent project')}
+                </div>
+                <ProjectSelector
+                    allProjects={self.props.projects}
+                    selectedProjectId={self.state.selectedProjectId}
+                    onChange={(value: string) => {
+                        self.setState({
+                            selectedProjectId: value,
+                        })
+                    }}
+                    excludeProjectId={'NONE'}
+                />
+            </div>
         )
     }
 }

--- a/src/containers/apps/CreateNewApp.tsx
+++ b/src/containers/apps/CreateNewApp.tsx
@@ -2,7 +2,7 @@ import { PlusCircleOutlined, QuestionCircleFilled } from '@ant-design/icons'
 import { Button, Card, Checkbox, Col, Input, Row, Tooltip } from 'antd'
 import { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import ProjectSelector from '../../components/ProjectSelector'
+import ParentProjectSelector from '../../components/ParentProjectSelector'
 import { IMobileComponent } from '../../models/ContainerProps'
 import ProjectDefinition from '../../models/ProjectDefinition'
 import { localize } from '../../utils/Language'
@@ -20,7 +20,7 @@ interface MyProps {
     projects: ProjectDefinition[]
 }
 
-class CreateNewApp extends Component<
+export class CreateNewApp extends Component<
     MyProps & IMobileComponent,
     { appName: string; selectedProjectId: string; hasPersistency: boolean }
 > {
@@ -212,31 +212,16 @@ class CreateNewApp extends Component<
     createProjectInApp() {
         const self = this
 
-        if ((self.props.projects || []).length === 0) {
-            return undefined
-        }
-
         return (
-            <div>
-                {' '}
-                <div
-                    style={{
-                        marginBottom: 5,
-                    }}
-                >
-                    {localize('apps.parent_project', 'Parent project')}
-                </div>
-                <ProjectSelector
-                    allProjects={self.props.projects}
-                    selectedProjectId={self.state.selectedProjectId}
-                    onChange={(value: string) => {
-                        self.setState({
-                            selectedProjectId: value,
-                        })
-                    }}
-                    excludeProjectId={'NONE'}
-                />
-            </div>
+            <ParentProjectSelector
+                projects={self.props.projects}
+                selectedProjectId={self.state.selectedProjectId}
+                onChange={(value: string) => {
+                    self.setState({
+                        selectedProjectId: value,
+                    })
+                }}
+            />
         )
     }
 }

--- a/src/containers/apps/compose/DockerComposeEntry.tsx
+++ b/src/containers/apps/compose/DockerComposeEntry.tsx
@@ -148,6 +148,7 @@ volumes:
                                 onChange={(selectedProjectId) => {
                                     self.setState({ selectedProjectId })
                                 }}
+                                hideWhenEmpty={false}
                                 style={{ marginTop: 24 }}
                             />
                             {isMultiService && (

--- a/src/containers/apps/compose/DockerComposeEntry.tsx
+++ b/src/containers/apps/compose/DockerComposeEntry.tsx
@@ -1,34 +1,69 @@
-import { Button, Card, Col, Row, Typography } from 'antd'
+import { Button, Card, Col, Input, Row, Typography } from 'antd'
 import { RouteComponentProps } from 'react-router'
+import ParentProjectSelector from '../../../components/ParentProjectSelector'
+import ProjectDefinition from '../../../models/ProjectDefinition'
 import { localize } from '../../../utils/Language'
+import {
+    isProjectNameAllowed,
+    normalizeProjectName,
+} from '../../../utils/ProjectName'
 import Toaster from '../../../utils/Toaster'
 import Utils from '../../../utils/Utils'
+import { createOneClickDeploymentUrl } from '../../../utils/OneClickDeploymentUrl'
 import ApiComponent from '../../global/ApiComponent'
+import CenteredSpinner from '../../global/CenteredSpinner'
+import ErrorRetry from '../../global/ErrorRetry'
 import InputJsonifier from '../../global/InputJsonifier'
-import {
-    DEPLOYMENT_QUERY_PARAM_APP_NAME,
-    DEPLOYMENT_QUERY_PARAM_TEMPLATE,
-    DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
-} from '../oneclick/variables/OneClickAppConfigPage'
 
 export const TEMPLATE_ONE_CLICK_APP = 'TEMPLATE_ONE_CLICK_APP'
 export const ONE_CLICK_APP_STRINGIFIED_KEY = 'oneClickAppStringifiedData'
 
-export default class OneClickAppSelector extends ApiComponent<
+export function getDockerComposeServiceCount(template: any): number {
+    if (!template?.services || typeof template.services !== 'object') {
+        return 0
+    }
+    return Object.keys(template.services).length
+}
+
+export default class DockerComposeEntry extends ApiComponent<
     RouteComponentProps<any>,
     {
         stringifiedJsonComposeContent: string
+        projects: ProjectDefinition[] | undefined
+        selectedProjectId: string
+        projectName: string
+        loadError: boolean
     }
 > {
     constructor(props: any) {
         super(props)
         this.state = {
             stringifiedJsonComposeContent: '',
+            projects: undefined,
+            selectedProjectId: '',
+            projectName: '',
+            loadError: false,
         }
     }
 
     componentDidMount() {
-        // const self = this
+        const self = this
+        self.apiManager
+            .getAllProjects()
+            .then(function (response) {
+                if (!self.willUnmountSoon) {
+                    self.setState({
+                        projects: (response.projects ||
+                            []) as ProjectDefinition[],
+                    })
+                }
+            })
+            .catch(function (error) {
+                Toaster.createCatcher()(error)
+                if (!self.willUnmountSoon) {
+                    self.setState({ loadError: true })
+                }
+            })
     }
 
     render() {
@@ -38,6 +73,20 @@ export default class OneClickAppSelector extends ApiComponent<
         try {
             parsedJson = JSON.parse(this.state.stringifiedJsonComposeContent)
         } catch (error) {}
+
+        if (self.state.loadError) {
+            return <ErrorRetry />
+        }
+
+        if (!self.state.projects) {
+            return <CenteredSpinner />
+        }
+
+        const serviceCount = getDockerComposeServiceCount(parsedJson)
+        const isMultiService = serviceCount > 1
+        const normalizedProjectName = normalizeProjectName(
+            self.state.projectName
+        )
 
         return (
             <div>
@@ -93,13 +142,57 @@ volumes:
                                     }}
                                 />
                             </div>
+                            <ParentProjectSelector
+                                projects={self.state.projects}
+                                selectedProjectId={self.state.selectedProjectId}
+                                onChange={(selectedProjectId) => {
+                                    self.setState({ selectedProjectId })
+                                }}
+                                style={{ marginTop: 24 }}
+                            />
+                            {isMultiService && (
+                                <div style={{ marginTop: 24 }}>
+                                    <div style={{ marginBottom: 5 }}>
+                                        {localize(
+                                            'projects.project_name',
+                                            'Project Name'
+                                        )}
+                                    </div>
+                                    <Input
+                                        aria-required="true"
+                                        placeholder="my-compose-stack"
+                                        value={self.state.projectName}
+                                        status={
+                                            self.state.projectName &&
+                                            !isProjectNameAllowed(
+                                                normalizedProjectName
+                                            )
+                                                ? 'error'
+                                                : undefined
+                                        }
+                                        onChange={(event) => {
+                                            self.setState({
+                                                projectName: event.target.value,
+                                            })
+                                        }}
+                                        onBlur={(event) => {
+                                            self.setState({
+                                                projectName:
+                                                    normalizeProjectName(
+                                                        event.target.value
+                                                    ),
+                                            })
+                                        }}
+                                    />
+                                </div>
+                            )}
                             <Row justify="end" style={{ marginTop: 15 }}>
                                 <Button
                                     size="large"
                                     style={{ minWidth: 150 }}
                                     type="primary"
                                     onClick={() => {
-                                        if (!parsedJson?.services) {
+                                        if (serviceCount === 0) {
                                             Toaster.toastError(
                                                 localize(
                                                     'one_click_app_selector.invalid_compose_json_toast',
@@ -108,7 +201,26 @@ volumes:
                                             )
                                             return
                                         }
-                                        self.deploy(parsedJson)
+                                        if (
+                                            isMultiService &&
+                                            !isProjectNameAllowed(
+                                                normalizedProjectName
+                                            )
+                                        ) {
+                                            Toaster.toastError(
+                                                localize(
+                                                    'docker_compose_entry.invalid_project_name',
+                                                    'Enter a valid lowercase project name using letters, numbers, and single hyphens.'
+                                                )
+                                            )
+                                            return
+                                        }
+                                        self.deploy(
+                                            parsedJson,
+                                            isMultiService
+                                                ? normalizedProjectName
+                                                : undefined
+                                        )
                                     }}
                                 >
                                     {' '}
@@ -124,12 +236,11 @@ volumes:
             </div>
         )
     }
-    deploy(template: any) {
+    deploy(template: any, projectName?: string) {
         const self = this
-        // Navigate to deployment page with template and values
-        // TODO move the constants to a common file
-        template.captainVersion = 4
-        template.caproverOneClickApp = {
+        const deploymentTemplate = Utils.copyObject(template)
+        deploymentTemplate.captainVersion = 4
+        deploymentTemplate.caproverOneClickApp = {
             instructions: {
                 start: localize(
                     'docker_compose_entry.start_instruction_text',
@@ -143,11 +254,13 @@ volumes:
             variables: [],
         }
 
-        const templateStr = encodeURIComponent(JSON.stringify(template))
-        const valuesArrayStr = encodeURIComponent(JSON.stringify([]))
-        const appName = 'Docker Compose'
-
-        const deployUrl = `/apps/oneclick/deployment?${DEPLOYMENT_QUERY_PARAM_TEMPLATE}=${templateStr}&${DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY}=${valuesArrayStr}&${DEPLOYMENT_QUERY_PARAM_APP_NAME}=${appName}`
+        const deployUrl = createOneClickDeploymentUrl({
+            template: deploymentTemplate,
+            valuesArray: [],
+            appName: 'Docker Compose',
+            parentProjectId: self.state.selectedProjectId,
+            projectName,
+        })
         self.props.history.push(deployUrl)
     }
 }

--- a/src/containers/apps/oneclick/variables/OneClickAppConfigPage.tsx
+++ b/src/containers/apps/oneclick/variables/OneClickAppConfigPage.tsx
@@ -176,6 +176,7 @@ export default class OneClickAppConfigPage extends ApiComponent<
                                 onChange={(selectedProjectId) => {
                                     self.setState({ selectedProjectId })
                                 }}
+                                hideWhenEmpty={false}
                                 style={{ marginBottom: 24 }}
                             />
                             <OneClickVariablesSection

--- a/src/containers/apps/oneclick/variables/OneClickAppConfigPage.tsx
+++ b/src/containers/apps/oneclick/variables/OneClickAppConfigPage.tsx
@@ -2,12 +2,16 @@ import { Card, Col, Row } from 'antd'
 import ReactMarkdown from 'react-markdown'
 import { RouteComponentProps } from 'react-router'
 import gfm from 'remark-gfm'
+import ParentProjectSelector from '../../../../components/ParentProjectSelector'
 import { IOneClickTemplate } from '../../../../models/IOneClickAppModels'
+import ProjectDefinition from '../../../../models/ProjectDefinition'
 import ErrorFactory from '../../../../utils/ErrorFactory'
 import Toaster from '../../../../utils/Toaster'
 import Utils from '../../../../utils/Utils'
+import { createOneClickDeploymentUrl } from '../../../../utils/OneClickDeploymentUrl'
 import ApiComponent from '../../../global/ApiComponent'
 import CenteredSpinner from '../../../global/CenteredSpinner'
+import ErrorRetry from '../../../global/ErrorRetry'
 import {
     ONE_CLICK_APP_STRINGIFIED_KEY,
     TEMPLATE_ONE_CLICK_APP,
@@ -17,16 +21,20 @@ import OneClickVariablesSection from './OneClickVariablesSection'
 export const ONE_CLICK_APP_NAME_VAR_NAME = '$$cap_appname'
 export const ONE_CLICK_ROOT_DOMAIN_VAR_NAME = '$$cap_root_domain'
 
-// Query parameter constants for deployment page
-export const DEPLOYMENT_QUERY_PARAM_TEMPLATE = 'template'
-export const DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY = 'valuesArray'
-export const DEPLOYMENT_QUERY_PARAM_APP_NAME = 'appName'
+export {
+    DEPLOYMENT_QUERY_PARAM_APP_NAME,
+    DEPLOYMENT_QUERY_PARAM_TEMPLATE,
+    DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
+} from '../../../../utils/OneClickDeploymentUrl'
 
 export default class OneClickAppConfigPage extends ApiComponent<
     RouteComponentProps<any>,
     {
         apiData: IOneClickTemplate | undefined
         rootDomain: string
+        projects: ProjectDefinition[] | undefined
+        selectedProjectId: string
+        loadError: boolean
     }
 > {
     private isUnmount: boolean = false
@@ -36,6 +44,9 @@ export default class OneClickAppConfigPage extends ApiComponent<
         this.state = {
             apiData: undefined,
             rootDomain: '',
+            projects: undefined,
+            selectedProjectId: '',
+            loadError: false,
         }
     }
 
@@ -51,7 +62,7 @@ export default class OneClickAppConfigPage extends ApiComponent<
         const appNameFromPath = this.props.match.params.appName
         const qs = new URLSearchParams(self.props.location.search)
         const baseDomainFromPath = qs.get('baseDomain')
-        let promiseToFetchOneClick =
+        const promiseToFetchOneClick =
             appNameFromPath === TEMPLATE_ONE_CLICK_APP
                 ? new Promise<any>(function (resolve) {
                       resolve(
@@ -68,8 +79,6 @@ export default class OneClickAppConfigPage extends ApiComponent<
                       .then(function (data) {
                           return data.appTemplate
                       })
-
-        let apiData: IOneClickTemplate
 
         promiseToFetchOneClick
             .then(function (data: IOneClickTemplate) {
@@ -98,17 +107,29 @@ export default class OneClickAppConfigPage extends ApiComponent<
                     validRegex: '/^([a-z0-9]+\\-)*[a-z0-9]+$/', // string version of /^([a-z0-9]+\-)*[a-z0-9]+$/
                 })
 
-                apiData = data
-
-                return self.apiManager.getCaptainInfo()
+                return Promise.all([
+                    Promise.resolve(data),
+                    self.apiManager.getCaptainInfo(),
+                    self.apiManager.getAllProjects(),
+                ])
             })
-            .then(function (captainInfo) {
+            .then(function ([apiData, captainInfo, projectsResponse]) {
+                if (self.isUnmount) {
+                    return
+                }
                 self.setState({
-                    apiData: apiData,
+                    apiData,
                     rootDomain: captainInfo.rootDomain,
+                    projects: (projectsResponse.projects ||
+                        []) as ProjectDefinition[],
                 })
             })
-            .catch(Toaster.createCatcher())
+            .catch(function (error) {
+                Toaster.createCatcher()(error)
+                if (!self.isUnmount) {
+                    self.setState({ loadError: true })
+                }
+            })
     }
 
     render() {
@@ -120,7 +141,11 @@ export default class OneClickAppConfigPage extends ApiComponent<
                 : self.props.match.params.appName[0].toUpperCase() +
                   self.props.match.params.appName.slice(1)
 
-        if (!apiData) {
+        if (self.state.loadError) {
+            return <ErrorRetry />
+        }
+
+        if (!apiData || !self.state.projects) {
             return <CenteredSpinner />
         }
 
@@ -145,6 +170,14 @@ export default class OneClickAppConfigPage extends ApiComponent<
                                 </ReactMarkdown>
                             </div>
                             <div style={{ height: 40 }} />
+                            <ParentProjectSelector
+                                projects={self.state.projects || []}
+                                selectedProjectId={self.state.selectedProjectId}
+                                onChange={(selectedProjectId) => {
+                                    self.setState({ selectedProjectId })
+                                }}
+                                style={{ marginBottom: 24 }}
+                            />
                             <OneClickVariablesSection
                                 oneClickAppVariables={
                                     apiData.caproverOneClickApp.variables
@@ -175,18 +208,16 @@ export default class OneClickAppConfigPage extends ApiComponent<
                                         }
                                     })
 
-                                    // Navigate to deployment page with template and values
-                                    const templateStr = encodeURIComponent(
-                                        JSON.stringify(template)
-                                    )
-                                    const valuesArrayStr = encodeURIComponent(
-                                        JSON.stringify(valuesArray)
-                                    )
-                                    const appName = encodeURIComponent(
+                                    const appName =
                                         self.props.match.params.appName
-                                    )
-
-                                    const deployUrl = `/apps/oneclick/deployment?${DEPLOYMENT_QUERY_PARAM_TEMPLATE}=${templateStr}&${DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY}=${valuesArrayStr}&${DEPLOYMENT_QUERY_PARAM_APP_NAME}=${appName}`
+                                    const deployUrl =
+                                        createOneClickDeploymentUrl({
+                                            template,
+                                            valuesArray,
+                                            appName,
+                                            parentProjectId:
+                                                self.state.selectedProjectId,
+                                        })
                                     self.props.history.push(deployUrl)
                                 }}
                             />

--- a/src/containers/apps/oneclick/variables/OneClickDeploymentPage.tsx
+++ b/src/containers/apps/oneclick/variables/OneClickDeploymentPage.tsx
@@ -1,14 +1,10 @@
 import { RouteComponentProps } from 'react-router'
 import { IOneClickTemplate } from '../../../../models/IOneClickAppModels'
 import DomUtils from '../../../../utils/DomUtils'
+import { parseOneClickDeploymentUrl } from '../../../../utils/OneClickDeploymentUrl'
 import Toaster from '../../../../utils/Toaster'
 import ApiComponent from '../../../global/ApiComponent'
 import CenteredSpinner from '../../../global/CenteredSpinner'
-import {
-    DEPLOYMENT_QUERY_PARAM_APP_NAME,
-    DEPLOYMENT_QUERY_PARAM_TEMPLATE,
-    DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
-} from './OneClickAppConfigPage'
 import OneClickAppDeployProgress from './OneClickAppDeployProgress'
 
 export default class OneClickDeploymentPage extends ApiComponent<
@@ -40,37 +36,29 @@ export default class OneClickDeploymentPage extends ApiComponent<
 
     componentDidMount() {
         const self = this
-        const qs = new URLSearchParams(self.props.location.search)
-
-        const templateStr = qs.get(DEPLOYMENT_QUERY_PARAM_TEMPLATE)
-        const valuesArrayStr = qs.get(DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY)
-        const appName = qs.get(DEPLOYMENT_QUERY_PARAM_APP_NAME) || ''
-
-        if (!templateStr || !valuesArrayStr || !appName) {
-            Toaster.createCatcher()(
-                'Missing required parameters for deployment'
-            )
-            self.props.history.goBack()
-            return
-        }
 
         try {
-            const template = JSON.parse(templateStr) as IOneClickTemplate
-            const valuesArray = JSON.parse(valuesArrayStr) as Array<{
-                key: string
-                value: string
-            }>
+            const deployment = parseOneClickDeploymentUrl(
+                self.props.location.search
+            )
 
             self.setState({
-                appName,
-                template,
-                valuesArray,
+                appName: deployment.appName,
+                template: deployment.template,
+                valuesArray: deployment.valuesArray,
             })
 
             // Start deployment immediately
             DomUtils.scrollToTopBar()
             self.apiManager
-                .startOneClickAppDeploy(template, valuesArray)
+                .startOneClickAppDeploy(
+                    deployment.template,
+                    deployment.valuesArray,
+                    {
+                        parentProjectId: deployment.parentProjectId,
+                        projectName: deployment.projectName,
+                    }
+                )
                 .then((data: any) => {
                     // store job id and render progress component
                     self.setState({

--- a/src/utils/OneClickDeploymentUrl.test.ts
+++ b/src/utils/OneClickDeploymentUrl.test.ts
@@ -1,0 +1,53 @@
+import { IOneClickTemplate } from '../models/IOneClickAppModels'
+import {
+    createOneClickDeploymentUrl,
+    parseOneClickDeploymentUrl,
+} from './OneClickDeploymentUrl'
+
+const template: IOneClickTemplate = {
+    captainVersion: 4,
+    services: {
+        web: { image: 'nginx:1.27' },
+    },
+    caproverOneClickApp: {
+        displayName: 'Web & API',
+        instructions: { start: 'Start', end: 'Done' },
+        variables: [],
+    },
+}
+
+describe('one-click deployment URL', () => {
+    it('round-trips the parent project and Compose group name', () => {
+        const url = createOneClickDeploymentUrl({
+            template,
+            valuesArray: [{ key: 'PASSWORD', value: 'a&b=c' }],
+            appName: 'Docker Compose',
+            parentProjectId: ' parent-id ',
+            projectName: ' compose-stack ',
+        })
+
+        const parsed = parseOneClickDeploymentUrl(url.split('?')[1])
+
+        expect(parsed).toEqual({
+            template,
+            valuesArray: [{ key: 'PASSWORD', value: 'a&b=c' }],
+            appName: 'Docker Compose',
+            parentProjectId: 'parent-id',
+            projectName: 'compose-stack',
+        })
+    })
+
+    it('keeps root as the default for legacy deployment URLs', () => {
+        const url = createOneClickDeploymentUrl({
+            template,
+            valuesArray: [],
+            appName: 'nginx',
+            parentProjectId: '',
+        })
+
+        const parsed = parseOneClickDeploymentUrl(url.split('?')[1])
+
+        expect(parsed.parentProjectId).toBe('')
+        expect(parsed.projectName).toBeUndefined()
+    })
+})

--- a/src/utils/OneClickDeploymentUrl.ts
+++ b/src/utils/OneClickDeploymentUrl.ts
@@ -1,0 +1,69 @@
+import { IOneClickTemplate } from '../models/IOneClickAppModels'
+
+export const DEPLOYMENT_QUERY_PARAM_TEMPLATE = 'template'
+export const DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY = 'valuesArray'
+export const DEPLOYMENT_QUERY_PARAM_APP_NAME = 'appName'
+export const DEPLOYMENT_QUERY_PARAM_PARENT_PROJECT_ID = 'parentProjectId'
+export const DEPLOYMENT_QUERY_PARAM_PROJECT_NAME = 'projectName'
+
+export interface OneClickDeploymentUrlData {
+    template: IOneClickTemplate
+    valuesArray: Array<{ key: string; value: string }>
+    appName: string
+    parentProjectId: string
+    projectName?: string
+}
+
+export function createOneClickDeploymentUrl(
+    data: OneClickDeploymentUrlData
+): string {
+    const query = new URLSearchParams()
+    query.set(DEPLOYMENT_QUERY_PARAM_TEMPLATE, JSON.stringify(data.template))
+    query.set(
+        DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
+        JSON.stringify(data.valuesArray)
+    )
+    query.set(DEPLOYMENT_QUERY_PARAM_APP_NAME, data.appName)
+    query.set(
+        DEPLOYMENT_QUERY_PARAM_PARENT_PROJECT_ID,
+        `${data.parentProjectId || ''}`.trim()
+    )
+
+    if (data.projectName !== undefined) {
+        query.set(
+            DEPLOYMENT_QUERY_PARAM_PROJECT_NAME,
+            `${data.projectName || ''}`.trim()
+        )
+    }
+    return `/apps/oneclick/deployment?${query.toString()}`
+}
+
+export function parseOneClickDeploymentUrl(
+    search: string
+): OneClickDeploymentUrlData {
+    const query = new URLSearchParams(search)
+    const templateString = query.get(DEPLOYMENT_QUERY_PARAM_TEMPLATE)
+    const valuesArrayString = query.get(DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY)
+    const appName = query.get(DEPLOYMENT_QUERY_PARAM_APP_NAME)
+
+    if (!templateString || !valuesArrayString || !appName) {
+        throw new Error('Missing required parameters for deployment')
+    }
+
+    const valuesArray = JSON.parse(valuesArrayString)
+    if (!Array.isArray(valuesArray)) {
+        throw new Error('Invalid values array for deployment')
+    }
+
+    const projectName = query.get(DEPLOYMENT_QUERY_PARAM_PROJECT_NAME)
+    return {
+        template: JSON.parse(templateString) as IOneClickTemplate,
+        valuesArray,
+        appName,
+        parentProjectId: `${
+            query.get(DEPLOYMENT_QUERY_PARAM_PARENT_PROJECT_ID) || ''
+        }`.trim(),
+        projectName:
+            projectName === null ? undefined : `${projectName || ''}`.trim(),
+    }
+}

--- a/src/utils/ProjectName.test.ts
+++ b/src/utils/ProjectName.test.ts
@@ -1,0 +1,25 @@
+import { isProjectNameAllowed, normalizeProjectName } from './ProjectName'
+
+describe('project name rules', () => {
+    it('normalizes user input to lowercase kebab-case', () => {
+        expect(normalizeProjectName('  My Compose Stack  ')).toBe(
+            'my-compose-stack'
+        )
+    })
+
+    it.each(['compose', 'compose-2', 'a1'])('accepts %p', (name) => {
+        expect(isProjectNameAllowed(name)).toBe(true)
+    })
+
+    it.each([
+        '',
+        'Compose',
+        '-compose',
+        'compose-',
+        'compose--stack',
+        'root',
+        'captain',
+    ])('rejects %p', (name) => {
+        expect(isProjectNameAllowed(name)).toBe(false)
+    })
+})

--- a/src/utils/ProjectName.ts
+++ b/src/utils/ProjectName.ts
@@ -1,0 +1,15 @@
+export function normalizeProjectName(name: string): string {
+    return `${name || ''}`.trim().toLowerCase().replace(/\s+/g, '-')
+}
+
+export function isProjectNameAllowed(name: string): boolean {
+    return (
+        !!name &&
+        name.length < 50 &&
+        /^[a-z]/.test(name) &&
+        /[a-z0-9]$/.test(name) &&
+        /^[a-z0-9-]+$/.test(name) &&
+        name.indexOf('--') < 0 &&
+        ['captain', 'root'].indexOf(name) < 0
+    )
+}


### PR DESCRIPTION
## Summary

- Add a shared parent-project selector to official/custom one-click and Docker Compose setup flows.
- Preserve root selection and clear behavior, including the empty-project state required by one-click and Compose.
- Carry `parentProjectId` and Compose group `projectName` through the deployment URL and API request.
- Validate and normalize multi-service Compose project names and block deployment when project loading fails.

## Screenshot

<img width="1745" height="781" alt="image" src="https://github.com/user-attachments/assets/b722e2db-9bef-4a97-ab1d-c031e61ea707" />



## Verification

- `yarn formatter`
- `yarn tslint`
- `CI=true yarn test --watchAll=false --runInBand` (6 suites, 28 passed)
- `yarn build`
- Manual local deployment flow verified by the requester.

## Related backend PR

- https://github.com/caprover/caprover/pull/2417

The local `.env` file was not modified or included.