### PR TITLE
feat(app-configs): warn when persistent volume label is used by other apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ cypress/videos/
 
 public/dark-theme.css
 public/light-theme.css
+.env
+.gitlock

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,3 @@ cypress/videos/
 
 public/dark-theme.css
 public/light-theme.css
-.env
-.gitlock

--- a/src/api/ApiManager.ts
+++ b/src/api/ApiManager.ts
@@ -1,4 +1,5 @@
 import CapRoverAPI from 'caprover-api'
+import { VolumesListResponse } from '../models/VolumeInfo'
 import Logger from '../utils/Logger'
 import StorageHelper from '../utils/StorageHelper'
 
@@ -67,5 +68,13 @@ export default class ApiManager extends CapRoverAPI {
 
                 return Promise.reject(error)
             })
+    }
+
+    getAllVolumes(): Promise<VolumesListResponse> {
+        return this.executeGenericApiCommand(
+            'GET',
+            '/user/system/volumes/',
+            {}
+        ) as Promise<VolumesListResponse>
     }
 }

--- a/src/containers/apps/appDetails/AppConfigs.tsx
+++ b/src/containers/apps/appDetails/AppConfigs.tsx
@@ -1,9 +1,15 @@
 import { EditFilled, EditOutlined, InfoCircleOutlined } from '@ant-design/icons'
-import { Button, Col, Input, Row, Switch, Tag, Tooltip } from 'antd'
+import { Alert, Button, Col, Input, Row, Switch, Tag, Tooltip } from 'antd'
 import { Component, Fragment } from 'react'
 import { IHashMapGeneric } from '../../../models/IHashMapGeneric'
+import { VolumeListItem } from '../../../models/VolumeInfo'
 import { localize } from '../../../utils/Language'
+import Logger from '../../../utils/Logger'
 import Utils from '../../../utils/Utils'
+import {
+    getOtherAppsUsingVolume,
+    resolvePhysicalVolumeName,
+} from '../../../utils/volumeHelpers'
 import CodeEdit from '../../global/CodeEdit'
 import NewTabLink from '../../global/NewTabLink'
 import { IAppEnvVar } from '../AppDefinition'
@@ -18,8 +24,13 @@ export default class AppConfigs extends Component<
         envVarBulkVals: string
         forceEditableNodeId: boolean
         forceEditableInstanceCount: boolean
+        volumes: VolumeListItem[]
+        volumesLoading: boolean
+        volumesFetchFailed: boolean
     }
 > {
+    private willUnmountSoon = false
+
     constructor(props: any) {
         super(props)
         this.state = {
@@ -29,7 +40,53 @@ export default class AppConfigs extends Component<
             envVarBulkEdit: false,
             envVarBulkVals: '',
             forceEditableNodeId: false,
+            volumes: [],
+            volumesLoading: false,
+            volumesFetchFailed: false,
         }
+    }
+
+    componentDidMount() {
+        this.loadVolumesInventory()
+    }
+
+    componentWillUnmount() {
+        this.willUnmountSoon = true
+    }
+
+    loadVolumesInventory() {
+        const self = this
+        if (!self.props.apiData.appDefinition.hasPersistentData) {
+            return
+        }
+        self.setState({ volumesLoading: true })
+        self.props.apiManager
+            .getAllVolumes()
+            .then((data: { volumes?: VolumeListItem[] }) => {
+                if (self.willUnmountSoon) {
+                    return
+                }
+                self.setState({
+                    volumes: data.volumes || [],
+                    volumesLoading: false,
+                    volumesFetchFailed: false,
+                })
+            })
+            .catch((err) => {
+                // intentional: no Toaster — older backends / 2440 not deployed
+                Logger.dev(
+                    'Failed to load volumes inventory: ' +
+                        (err && err.message ? err.message : String(err))
+                )
+                if (self.willUnmountSoon) {
+                    return
+                }
+                self.setState({
+                    volumes: [],
+                    volumesLoading: false,
+                    volumesFetchFailed: true,
+                })
+            })
     }
 
     // Copied from https://github.com/motdotla/dotenv/blob/master/lib/main.js
@@ -248,128 +305,164 @@ export default class AppConfigs extends Component<
 
     createVolRows() {
         const self = this
-        const volumes = this.props.apiData.appDefinition.volumes || []
+        const app = this.props.apiData.appDefinition
+        const volumes = app.volumes || []
         return volumes.map((value, index) => {
-            return (
-                <Row style={{ paddingBottom: 12 }} key={`${index}`}>
-                    <Col span={8}>
-                        <Input
-                            addonBefore={localize(
-                                'apps.app_config_vol_path',
-                                'Path in App'
-                            )}
-                            spellCheck={false}
-                            autoCorrect="off"
-                            autoComplete="off"
-                            autoCapitalize="off"
-                            className="code-input"
-                            placeholder="/var/www/html"
-                            value={value.containerPath}
-                            type="text"
-                            onChange={(e) => {
-                                const newApiData = Utils.copyObject(
-                                    self.props.apiData
-                                )
-                                newApiData.appDefinition.volumes[
-                                    index
-                                ].containerPath = e.target.value
-                                self.props.updateApiData(newApiData)
-                            }}
-                        />
-                    </Col>
-                    <Col
-                        style={{ paddingLeft: 12 }}
-                        span={8}
-                        className={value.hostPath ? 'hide-on-demand' : ''}
-                    >
-                        <Input
-                            addonBefore={localize(
-                                'apps.app_config_vol_label',
-                                'Label'
-                            )}
-                            spellCheck={false}
-                            autoCorrect="off"
-                            autoComplete="off"
-                            autoCapitalize="off"
-                            className="code-input"
-                            placeholder="some-name"
-                            value={value.volumeName}
-                            onChange={(e) => {
-                                const newApiData = Utils.copyObject(
-                                    self.props.apiData
-                                )
-                                newApiData.appDefinition.volumes[
-                                    index
-                                ].volumeName = e.target.value
-                                self.props.updateApiData(newApiData)
-                            }}
-                        />
-                    </Col>
+            // Bind mounts: Label is hidden; do not warn on volume sharing
+            const otherApps =
+                value.hostPath
+                    ? []
+                    : getOtherAppsUsingVolume(
+                          resolvePhysicalVolumeName(
+                              value.volumeName || '',
+                              app.isLegacyAppName
+                          ),
+                          self.state.volumes,
+                          app.appName
+                      )
 
-                    <Col
-                        style={{ paddingLeft: 12 }}
-                        span={8}
-                        className={!value.hostPath ? 'hide-on-demand' : ''}
+            return (
+                <div key={`${index}`}>
+                    <Row
+                        style={{
+                            paddingBottom: otherApps.length ? 4 : 12,
+                        }}
                     >
-                        <Tooltip
-                            title={localize(
-                                'apps.app_config_vol_host_path_hint',
-                                'IMPORTANT: Ensure Host Path exists before assigning it here'
-                            )}
-                        >
+                        <Col span={8}>
                             <Input
                                 addonBefore={localize(
-                                    'apps.app_config_vol_host_path',
-                                    'Path on Host'
+                                    'apps.app_config_vol_path',
+                                    'Path in App'
                                 )}
                                 spellCheck={false}
                                 autoCorrect="off"
                                 autoComplete="off"
                                 autoCapitalize="off"
                                 className="code-input"
-                                placeholder="/host/path/exists"
-                                value={value.hostPath}
+                                placeholder="/var/www/html"
+                                value={value.containerPath}
+                                type="text"
                                 onChange={(e) => {
                                     const newApiData = Utils.copyObject(
                                         self.props.apiData
                                     )
                                     newApiData.appDefinition.volumes[
                                         index
-                                    ].hostPath = e.target.value
+                                    ].containerPath = e.target.value
                                     self.props.updateApiData(newApiData)
                                 }}
                             />
-                        </Tooltip>
-                    </Col>
-                    <Col style={{ paddingLeft: 12 }} span={8}>
-                        <Button
-                            type="dashed"
-                            onClick={() => {
-                                const newApiData = Utils.copyObject(
-                                    self.props.apiData
-                                )
-                                newApiData.appDefinition.volumes[
-                                    index
-                                ].hostPath = newApiData.appDefinition.volumes[
-                                    index
-                                ].hostPath
-                                    ? ''
-                                    : '/'
-                                self.props.updateApiData(newApiData)
-                            }}
+                        </Col>
+                        <Col
+                            style={{ paddingLeft: 12 }}
+                            span={8}
+                            className={value.hostPath ? 'hide-on-demand' : ''}
                         >
-                            {value.hostPath
-                                ? localize(
-                                      'apps.app_config_vol_manage_path',
-                                      'Let CapRover manage path'
-                                  )
-                                : localize(
-                                      'apps.app_config_vol_set_path',
-                                      'Set specific host path'
-                                  )}
-                        </Button>
-                    </Col>
-                </Row>
+                            <Input
+                                addonBefore={localize(
+                                    'apps.app_config_vol_label',
+                                    'Label'
+                                )}
+                                spellCheck={false}
+                                autoCorrect="off"
+                                autoComplete="off"
+                                autoCapitalize="off"
+                                className="code-input"
+                                placeholder="some-name"
+                                value={value.volumeName}
+                                onChange={(e) => {
+                                    const newApiData = Utils.copyObject(
+                                        self.props.apiData
+                                    )
+                                    newApiData.appDefinition.volumes[
+                                        index
+                                    ].volumeName = e.target.value
+                                    self.props.updateApiData(newApiData)
+                                }}
+                            />
+                        </Col>
+
+                        <Col
+                            style={{ paddingLeft: 12 }}
+                            span={8}
+                            className={!value.hostPath ? 'hide-on-demand' : ''}
+                        >
+                            <Tooltip
+                                title={localize(
+                                    'apps.app_config_vol_host_path_hint',
+                                    'IMPORTANT: Ensure Host Path exists before assigning it here'
+                                )}
+                            >
+                                <Input
+                                    addonBefore={localize(
+                                        'apps.app_config_vol_host_path',
+                                        'Path on Host'
+                                    )}
+                                    spellCheck={false}
+                                    autoCorrect="off"
+                                    autoComplete="off"
+                                    autoCapitalize="off"
+                                    className="code-input"
+                                    placeholder="/host/path/exists"
+                                    value={value.hostPath}
+                                    onChange={(e) => {
+                                        const newApiData = Utils.copyObject(
+                                            self.props.apiData
+                                        )
+                                        newApiData.appDefinition.volumes[
+                                            index
+                                        ].hostPath = e.target.value
+                                        self.props.updateApiData(newApiData)
+                                    }}
+                                />
+                            </Tooltip>
+                        </Col>
+                        <Col style={{ paddingLeft: 12 }} span={8}>
+                            <Button
+                                type="dashed"
+                                onClick={() => {
+                                    const newApiData = Utils.copyObject(
+                                        self.props.apiData
+                                    )
+                                    newApiData.appDefinition.volumes[
+                                        index
+                                    ].hostPath =
+                                        newApiData.appDefinition.volumes[index]
+                                            .hostPath
+                                            ? ''
+                                            : '/'
+                                    self.props.updateApiData(newApiData)
+                                }}
+                            >
+                                {value.hostPath
+                                    ? localize(
+                                          'apps.app_config_vol_manage_path',
+                                          'Let CapRover manage path'
+                                      )
+                                    : localize(
+                                          'apps.app_config_vol_set_path',
+                                          'Set specific host path'
+                                      )}
+                            </Button>
+                        </Col>
+                    </Row>
+                    {otherApps.length > 0 ? (
+                        <Row style={{ paddingBottom: 12 }}>
+                            <Col span={24}>
+                                <Alert
+                                    type="warning"
+                                    showIcon={true}
+                                    message={localize(
+                                        'apps.app_config_vol_in_use_warning',
+                                        'This volume is already used by other application(s): %s'
+                                    )
+                                        .split('%s')
+                                        .join(otherApps.join(', '))}
+                                />
+                            </Col>
+                        </Row>
+                    ) : null}
+                </div>
             )
         })
     }

--- a/src/containers/apps/appDetails/AppConfigs.tsx
+++ b/src/containers/apps/appDetails/AppConfigs.tsx
@@ -7,6 +7,7 @@ import { localize } from '../../../utils/Language'
 import Logger from '../../../utils/Logger'
 import Utils from '../../../utils/Utils'
 import {
+    formatLocalized,
     getOtherAppsUsingVolume,
     resolvePhysicalVolumeName,
 } from '../../../utils/volumeHelpers'
@@ -24,9 +25,7 @@ export default class AppConfigs extends Component<
         envVarBulkVals: string
         forceEditableNodeId: boolean
         forceEditableInstanceCount: boolean
-        volumes: VolumeListItem[]
-        volumesLoading: boolean
-        volumesFetchFailed: boolean
+        volumeInventory: VolumeListItem[]
     }
 > {
     private willUnmountSoon = false
@@ -40,9 +39,7 @@ export default class AppConfigs extends Component<
             envVarBulkEdit: false,
             envVarBulkVals: '',
             forceEditableNodeId: false,
-            volumes: [],
-            volumesLoading: false,
-            volumesFetchFailed: false,
+            volumeInventory: [],
         }
     }
 
@@ -59,7 +56,6 @@ export default class AppConfigs extends Component<
         if (!self.props.apiData.appDefinition.hasPersistentData) {
             return
         }
-        self.setState({ volumesLoading: true })
         self.props.apiManager
             .getAllVolumes()
             .then((data: { volumes?: VolumeListItem[] }) => {
@@ -67,9 +63,7 @@ export default class AppConfigs extends Component<
                     return
                 }
                 self.setState({
-                    volumes: data.volumes || [],
-                    volumesLoading: false,
-                    volumesFetchFailed: false,
+                    volumeInventory: data.volumes || [],
                 })
             })
             .catch((err) => {
@@ -82,9 +76,7 @@ export default class AppConfigs extends Component<
                     return
                 }
                 self.setState({
-                    volumes: [],
-                    volumesLoading: false,
-                    volumesFetchFailed: true,
+                    volumeInventory: [],
                 })
             })
     }
@@ -317,7 +309,7 @@ export default class AppConfigs extends Component<
                               value.volumeName || '',
                               app.isLegacyAppName
                           ),
-                          self.state.volumes,
+                          self.state.volumeInventory,
                           app.appName
                       )
 
@@ -452,12 +444,13 @@ export default class AppConfigs extends Component<
                                 <Alert
                                     type="warning"
                                     showIcon={true}
-                                    message={localize(
-                                        'apps.app_config_vol_in_use_warning',
-                                        'This volume is already used by other application(s): %s'
-                                    )
-                                        .split('%s')
-                                        .join(otherApps.join(', '))}
+                                    message={formatLocalized(
+                                        localize(
+                                            'apps.app_config_vol_in_use_warning',
+                                            'This volume is already used by other application(s): %s'
+                                        ),
+                                        otherApps.join(', ')
+                                    )}
                                 />
                             </Col>
                         </Row>

--- a/src/containers/apps/appDetails/AppConfigs.tsx
+++ b/src/containers/apps/appDetails/AppConfigs.tsx
@@ -301,17 +301,16 @@ export default class AppConfigs extends Component<
         const volumes = app.volumes || []
         return volumes.map((value, index) => {
             // Bind mounts: Label is hidden; do not warn on volume sharing
-            const otherApps =
-                value.hostPath
-                    ? []
-                    : getOtherAppsUsingVolume(
-                          resolvePhysicalVolumeName(
-                              value.volumeName || '',
-                              app.isLegacyAppName
-                          ),
-                          self.state.volumeInventory,
-                          app.appName
-                      )
+            const otherApps = value.hostPath
+                ? []
+                : getOtherAppsUsingVolume(
+                      resolvePhysicalVolumeName(
+                          value.volumeName || '',
+                          app.isLegacyAppName
+                      ),
+                      self.state.volumeInventory,
+                      app.appName
+                  )
 
             return (
                 <div key={`${index}`}>
@@ -418,11 +417,10 @@ export default class AppConfigs extends Component<
                                     )
                                     newApiData.appDefinition.volumes[
                                         index
-                                    ].hostPath =
-                                        newApiData.appDefinition.volumes[index]
-                                            .hostPath
-                                            ? ''
-                                            : '/'
+                                    ].hostPath = newApiData.appDefinition
+                                        .volumes[index].hostPath
+                                        ? ''
+                                        : '/'
                                     self.props.updateApiData(newApiData)
                                 }}
                             >

--- a/src/containers/apps/appDetails/AppConfigs.tsx
+++ b/src/containers/apps/appDetails/AppConfigs.tsx
@@ -454,7 +454,7 @@ export default class AppConfigs extends Component<
                                 />
                             </Col>
                         </Row>
-                    ) : null}
+                    ) : undefined}
                 </div>
             )
         })

--- a/src/locales/ar-EG.json
+++ b/src/locales/ar-EG.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "الأدلة المستمرة",
     "apps.app_config_vol_host_path": "المسار على الخادم",
     "apps.app_config_vol_host_path_hint": "مهم: تأكد من وجود المسار على الخادم قبل تعيينه هنا",
+    "apps.app_config_vol_in_use_warning": "هذا المجلد مستخدم بالفعل بواسطة تطبيق(ات) أخرى: %s",
     "apps.app_config_vol_label": "العلامة",
     "apps.app_config_vol_manage_path": "دع CapRover يدير المسار",
     "apps.app_config_vol_no_directories": "حاليًا، لا يمتلك هذا التطبيق أي أدلة مستمرة.",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Persistente Verzeichnisse",
     "apps.app_config_vol_host_path": "Hostpfad",
     "apps.app_config_vol_host_path_hint": "WICHTIG: Stellen Sie sicher, dass der Hostpfad vorhanden ist, bevor Sie ihn hier zuweisen",
+    "apps.app_config_vol_in_use_warning": "Dieses Volume wird bereits von anderen Anwendung(en) verwendet: %s",
     "apps.app_config_vol_label": "Bezeichnung",
     "apps.app_config_vol_manage_path": "Lassen Sie CapRover den Pfad verwalten",
     "apps.app_config_vol_no_directories": "Derzeit hat diese App keine persistenten Verzeichnisse.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Persistent Directories",
     "apps.app_config_vol_host_path": "Path on Host",
     "apps.app_config_vol_host_path_hint": "IMPORTANT: Ensure Host Path exists before assigning it here",
+    "apps.app_config_vol_in_use_warning": "This volume is already used by other application(s): %s",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Let CapRover manage path",
     "apps.app_config_vol_no_directories": "Currently, this app does not have any persistent directories.",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Directorios Persistentes",
     "apps.app_config_vol_host_path": "Ruta en el Host",
     "apps.app_config_vol_host_path_hint": "IMPORTANTE: Asegúrese de que la Ruta del Host exista antes de asignarla aquí",
+    "apps.app_config_vol_in_use_warning": "Este volumen ya está siendo usado por otra(s) aplicación(es): %s",
     "apps.app_config_vol_label": "Etiqueta",
     "apps.app_config_vol_manage_path": "Dejar que CapRover administre la ruta",
     "apps.app_config_vol_no_directories": "Actualmente, esta app no tiene ningún directorio persistente.",

--- a/src/locales/fa-IR.json
+++ b/src/locales/fa-IR.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "دایرکتوری‌های دائمی",
     "apps.app_config_vol_host_path": "مسیر روی میزبان",
     "apps.app_config_vol_host_path_hint": "مهم: قبل از اختصاص دادن آن در اینجا، اطمینان حاصل کنید که مسیر میزبان وجود دارد",
+    "apps.app_config_vol_in_use_warning": "این volume قبلاً توسط برنامه(های) دیگر استفاده می‌شود: %s",
     "apps.app_config_vol_label": "برچسب",
     "apps.app_config_vol_manage_path": "مدیریت مسیر توسط کپروور",
     "apps.app_config_vol_no_directories": "در حال حاضر، این برنامه هیچ دایرکتوری دائمی ندارد.",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Répertoires Persistants",
     "apps.app_config_vol_host_path": "Chemin sur l'Hôte",
     "apps.app_config_vol_host_path_hint": "IMPORTANT : Assurez-vous que le Chemin Hôte existe avant de l'assigner ici",
+    "apps.app_config_vol_in_use_warning": "Ce volume est déjà utilisé par d'autre(s) application(s) : %s",
     "apps.app_config_vol_label": "Libellé",
     "apps.app_config_vol_manage_path": "Laisser CapRover gérer le chemin",
     "apps.app_config_vol_no_directories": "Actuellement, cette app n'a pas de répertoires persistants.",

--- a/src/locales/hr-HR.json
+++ b/src/locales/hr-HR.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Trajni direktoriji",
     "apps.app_config_vol_host_path": "Putanja na hostu",
     "apps.app_config_vol_host_path_hint": "VAŽNO: Provjerite postoji li putanja na hostu prije nego što je ovdje dodijelite",
+    "apps.app_config_vol_in_use_warning": "Ovaj volume već koriste druge aplikacije: %s",
     "apps.app_config_vol_label": "Oznaka",
     "apps.app_config_vol_manage_path": "Prepusti CapRoveru upravljanje putanjom",
     "apps.app_config_vol_no_directories": "Trenutno ova aplikacija nema trajne direktorije.",

--- a/src/locales/id-ID.json
+++ b/src/locales/id-ID.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Direktori Persisten",
     "apps.app_config_vol_host_path": "Jalur di Host",
     "apps.app_config_vol_host_path_hint": "PENTING: Pastikan Jalur Host ada sebelum menetapkannya di sini",
+    "apps.app_config_vol_in_use_warning": "Volume ini sudah digunakan oleh aplikasi lain: %s",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Biarkan CapRover mengelola jalur",
     "apps.app_config_vol_no_directories": "Saat ini, aplikasi ini tidak memiliki direktori persisten.",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "영구 디렉터리",
     "apps.app_config_vol_host_path": "호스트 경로",
     "apps.app_config_vol_host_path_hint": "중요: 여기에 지정하기 전에 호스트 경로가 존재하는지 확인하세요",
+    "apps.app_config_vol_in_use_warning": "이 볼륨은 이미 다른 애플리케이션에서 사용 중입니다: %s",
     "apps.app_config_vol_label": "레이블",
     "apps.app_config_vol_manage_path": "CapRover가 경로 관리",
     "apps.app_config_vol_no_directories": "현재 이 앱에는 영구 디렉터리가 없습니다.",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Persistente mappen",
     "apps.app_config_vol_host_path": "Pad op host",
     "apps.app_config_vol_host_path_hint": "BELANGRIJK: Zorg ervoor dat het hostpad bestaat voordat je het hier toewijst",
+    "apps.app_config_vol_in_use_warning": "Dit volume wordt al gebruikt door andere applicatie(s): %s",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Laat CapRover het pad beheren",
     "apps.app_config_vol_no_directories": "Momenteel heeft deze app geen persistente mappen.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Diretórios Persistentes",
     "apps.app_config_vol_host_path": "Caminho no Host",
     "apps.app_config_vol_host_path_hint": "IMPORTANTE: Garanta que o Caminho do Host exista antes de atribuí-lo aqui",
+    "apps.app_config_vol_in_use_warning": "Este volume já está sendo usado por outro(s) aplicativo(s): %s",
     "apps.app_config_vol_label": "Rótulo",
     "apps.app_config_vol_manage_path": "Permitir que o CapRover gerencie o caminho",
     "apps.app_config_vol_no_directories": "Atualmente, este app não possui diretórios persistentes.",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Постоянные volume",
     "apps.app_config_vol_host_path": "Путь на хосте",
     "apps.app_config_vol_host_path_hint": "ВАЖНО: убедитесь, что путь на хосте существует",
+    "apps.app_config_vol_in_use_warning": "Этот volume уже используется другим приложением(ями): %s",
     "apps.app_config_vol_label": "Метка",
     "apps.app_config_vol_manage_path": "Разрешить CapRover управлять путём",
     "apps.app_config_vol_no_directories": "У этого приложения пока нет docker volumes.",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Beständiga mappar",
     "apps.app_config_vol_host_path": "Sökväg på värd",
     "apps.app_config_vol_host_path_hint": "VIKTIGT: Se till att värdvägen finns innan du tilldelar den här",
+    "apps.app_config_vol_in_use_warning": "Denna volym används redan av annan applikation/applikationer: %s",
     "apps.app_config_vol_label": "Etikett",
     "apps.app_config_vol_manage_path": "Låt CapRover hantera sökvägen",
     "apps.app_config_vol_no_directories": "För närvarande har denna app inga beständiga mappar.",

--- a/src/locales/tr-TR.json
+++ b/src/locales/tr-TR.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "Kalıcı Dizinler",
     "apps.app_config_vol_host_path": "Ev Sahibi Yolu",
     "apps.app_config_vol_host_path_hint": "ÖNEMLİ: Buraya atama yapmadan önce Ev Sahibi Yolu'nun var olduğundan emin olun",
+    "apps.app_config_vol_in_use_warning": "Bu birim zaten diğer uygulama(lar) tarafından kullanılıyor: %s",
     "apps.app_config_vol_label": "Etiket",
     "apps.app_config_vol_manage_path": "Yolu CapRover yönetir",
     "apps.app_config_vol_no_directories": "Şu anda, bu uygulamada herhangi bir kalıcı dizin yok.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -53,6 +53,7 @@
     "apps.app_config_vol_directories": "持久目录",
     "apps.app_config_vol_host_path": "主机路径",
     "apps.app_config_vol_host_path_hint": "重要：分配路径之前，请确保主机路径存在",
+    "apps.app_config_vol_in_use_warning": "此卷已被其他应用使用：%s",
     "apps.app_config_vol_label": "标签",
     "apps.app_config_vol_manage_path": "让 CapRover 管理路径",
     "apps.app_config_vol_no_directories": "当前，此应用没有任何持久目录。",

--- a/src/models/VolumeInfo.ts
+++ b/src/models/VolumeInfo.ts
@@ -1,0 +1,20 @@
+export interface DockerVolumeInfo {
+    name: string // physical Docker volume name
+    driver: string
+    mountpoint: string
+    scope: 'local' | 'global' | string
+    labels: { [key: string]: string } // always object (never null)
+    options: { [key: string]: string } | null
+    size?: number // rarely present; DO NOT use for conflict logic
+    refCount?: number // rarely present; DO NOT use for conflict logic
+    createdAt?: string
+}
+
+export interface VolumeListItem extends DockerVolumeInfo {
+    usedByAppNames: string[] // always present; CapRover app names
+    isLikelySystem: boolean // always present; UX heuristic only, NOT security
+}
+
+export interface VolumesListResponse {
+    volumes: VolumeListItem[]
+}

--- a/src/models/VolumeInfo.ts
+++ b/src/models/VolumeInfo.ts
@@ -4,7 +4,7 @@ export interface DockerVolumeInfo {
     mountpoint: string
     scope: 'local' | 'global' | string
     labels: { [key: string]: string } // always object (never null)
-    options: { [key: string]: string } | null
+    options?: { [key: string]: string }
     size?: number // rarely present; DO NOT use for conflict logic
     refCount?: number // rarely present; DO NOT use for conflict logic
     createdAt?: string

--- a/src/utils/volumeHelpers.test.ts
+++ b/src/utils/volumeHelpers.test.ts
@@ -138,3 +138,26 @@ describe('formatLocalized', () => {
         expect(formatLocalized('%s and %s', 'a')).toBe('a and a')
     })
 })
+
+describe('legacy resolve → getOtherAppsUsingVolume (AppConfigs path)', () => {
+    it('resolves logical label for legacy app and lists other apps', () => {
+        const inventory: VolumeListItem[] = [
+            makeVolume('captain--data', ['legacy-app', 'other-app']),
+        ]
+        const physical = resolvePhysicalVolumeName('data', true)
+        expect(physical).toBe('captain--data')
+        expect(
+            getOtherAppsUsingVolume(physical, inventory, 'legacy-app')
+        ).toEqual(['other-app'])
+    })
+
+    it('does not warn when only the current legacy app uses the volume', () => {
+        const inventory: VolumeListItem[] = [
+            makeVolume('captain--data', ['legacy-app']),
+        ]
+        const physical = resolvePhysicalVolumeName('data', true)
+        expect(
+            getOtherAppsUsingVolume(physical, inventory, 'legacy-app')
+        ).toEqual([])
+    })
+})

--- a/src/utils/volumeHelpers.test.ts
+++ b/src/utils/volumeHelpers.test.ts
@@ -1,0 +1,140 @@
+import { VolumeListItem } from '../models/VolumeInfo'
+import {
+    formatLocalized,
+    getOtherAppsUsingVolume,
+    resolvePhysicalVolumeName,
+} from './volumeHelpers'
+
+function makeVolume(
+    name: string,
+    usedByAppNames: string[],
+    isLikelySystem = false
+): VolumeListItem {
+    return {
+        name,
+        driver: 'local',
+        mountpoint: `/var/lib/docker/volumes/${name}/_data`,
+        scope: 'local',
+        labels: {},
+        options: null,
+        usedByAppNames,
+        isLikelySystem,
+    }
+}
+
+describe('resolvePhysicalVolumeName', () => {
+    it('returns empty string for empty or whitespace-only label', () => {
+        expect(resolvePhysicalVolumeName('', false)).toBe('')
+        expect(resolvePhysicalVolumeName('   ', false)).toBe('')
+        expect(resolvePhysicalVolumeName('', true)).toBe('')
+        expect(resolvePhysicalVolumeName(undefined as any, false)).toBe('')
+    })
+
+    it('returns label as-is for modern apps', () => {
+        expect(resolvePhysicalVolumeName('my-data', false)).toBe('my-data')
+        expect(resolvePhysicalVolumeName('my-data', undefined)).toBe('my-data')
+        expect(resolvePhysicalVolumeName('  my-data  ', false)).toBe('my-data')
+    })
+
+    it('prefixes namespace for legacy apps with default captain namespace', () => {
+        expect(resolvePhysicalVolumeName('data', true)).toBe('captain--data')
+        expect(resolvePhysicalVolumeName('  data  ', true)).toBe(
+            'captain--data'
+        )
+    })
+
+    it('uses custom namespace when provided for legacy apps', () => {
+        expect(resolvePhysicalVolumeName('data', true, 'custom')).toBe(
+            'custom--data'
+        )
+    })
+
+    it('does not rewrite modern labels that look like legacy physical names', () => {
+        expect(resolvePhysicalVolumeName('captain--data', false)).toBe(
+            'captain--data'
+        )
+    })
+})
+
+describe('getOtherAppsUsingVolume', () => {
+    const volumes: VolumeListItem[] = [
+        makeVolume('my-postgres-data', ['my-db', 'worker']),
+        makeVolume('captain--legacy-data', ['old-app']),
+        makeVolume('only-mine', ['current-app']),
+        makeVolume('unused-vol', []),
+    ]
+
+    it('returns empty array when physical name is empty', () => {
+        expect(getOtherAppsUsingVolume('', volumes, 'current-app')).toEqual([])
+    })
+
+    it('returns empty array when volume is not in inventory', () => {
+        expect(
+            getOtherAppsUsingVolume('unknown-vol', volumes, 'current-app')
+        ).toEqual([])
+    })
+
+    it('returns empty array for empty inventory', () => {
+        expect(
+            getOtherAppsUsingVolume('my-postgres-data', [], 'current-app')
+        ).toEqual([])
+    })
+
+    it('returns other apps using the volume', () => {
+        expect(
+            getOtherAppsUsingVolume('my-postgres-data', volumes, 'other-app')
+        ).toEqual(['my-db', 'worker'])
+    })
+
+    it('excludes the current app from the list', () => {
+        expect(
+            getOtherAppsUsingVolume('my-postgres-data', volumes, 'my-db')
+        ).toEqual(['worker'])
+        expect(
+            getOtherAppsUsingVolume('only-mine', volumes, 'current-app')
+        ).toEqual([])
+    })
+
+    it('returns empty when volume has no usedByAppNames', () => {
+        expect(
+            getOtherAppsUsingVolume('unused-vol', volumes, 'current-app')
+        ).toEqual([])
+    })
+
+    it('handles missing usedByAppNames gracefully', () => {
+        const broken = [
+            {
+                ...makeVolume('broken', []),
+                usedByAppNames: undefined as any,
+            },
+        ]
+        expect(getOtherAppsUsingVolume('broken', broken, 'app')).toEqual([])
+    })
+
+    it('matches legacy physical names', () => {
+        expect(
+            getOtherAppsUsingVolume(
+                'captain--legacy-data',
+                volumes,
+                'current-app'
+            )
+        ).toEqual(['old-app'])
+    })
+})
+
+describe('formatLocalized', () => {
+    it('replaces %s with the provided value', () => {
+        expect(
+            formatLocalized(
+                'This volume is already used by other application(s): %s',
+                'my-db, worker'
+            )
+        ).toBe(
+            'This volume is already used by other application(s): my-db, worker'
+        )
+    })
+
+    it('replaces all %s occurrences', () => {
+        expect(formatLocalized('%s and %s', 'a')).toBe('a and a')
+    })
+})

--- a/src/utils/volumeHelpers.test.ts
+++ b/src/utils/volumeHelpers.test.ts
@@ -16,7 +16,6 @@ function makeVolume(
         mountpoint: `/var/lib/docker/volumes/${name}/_data`,
         scope: 'local',
         labels: {},
-        options: undefined,
         usedByAppNames,
         isLikelySystem,
     }

--- a/src/utils/volumeHelpers.test.ts
+++ b/src/utils/volumeHelpers.test.ts
@@ -16,7 +16,7 @@ function makeVolume(
         mountpoint: `/var/lib/docker/volumes/${name}/_data`,
         scope: 'local',
         labels: {},
-        options: null,
+        options: undefined,
         usedByAppNames,
         isLikelySystem,
     }

--- a/src/utils/volumeHelpers.ts
+++ b/src/utils/volumeHelpers.ts
@@ -1,0 +1,50 @@
+import { VolumeListItem } from '../models/VolumeInfo'
+
+const DEFAULT_NAMESPACE = 'captain'
+
+/**
+ * Resolve the physical Docker volume name from a logical label.
+ * Modern apps use the label as-is; legacy apps use `${namespace}--${label}`.
+ */
+export function resolvePhysicalVolumeName(
+    volumeName: string,
+    isLegacyAppName: boolean | undefined,
+    namespace: string = DEFAULT_NAMESPACE
+): string {
+    const label = (volumeName || '').trim()
+    if (!label) {
+        return ''
+    }
+    if (isLegacyAppName) {
+        return `${namespace}--${label}`
+    }
+    return label
+}
+
+/**
+ * Return CapRover app names (excluding currentAppName) that already use
+ * the given physical Docker volume name.
+ */
+export function getOtherAppsUsingVolume(
+    physicalName: string,
+    volumes: VolumeListItem[],
+    currentAppName: string | undefined
+): string[] {
+    if (!physicalName) {
+        return []
+    }
+    const match = volumes.find((v) => v.name === physicalName)
+    if (!match) {
+        return []
+    }
+    return (match.usedByAppNames || []).filter(
+        (name) => name !== currentAppName
+    )
+}
+
+/**
+ * Replace a single `%s` placeholder in a localized template string.
+ */
+export function formatLocalized(template: string, value: string): string {
+    return template.split('%s').join(value)
+}


### PR DESCRIPTION
## Summary
- Auto-fetch Docker named volume inventory via `GET /user/system/volumes/` (CapRover PR #2440) when App Configs loads for apps with persistent data.
- When a Persistent Directories **Label** maps to a volume used by **other** CapRover apps, show a yellow warning `Alert` under that volume row.
- Warn-only — does not block Save. Silent degrade if the API is unavailable (older CapRover / 2440 not deployed).

## Design notes
- Label control remains plain Ant Design `Input` (no AutoComplete/Select).
- Legacy apps resolve physical names as `captain--{label}`.
- Mount-only inventory fetch with unmount safety.

## Test plan
- [x] Unit tests: `yarn test --watchAll=false --testPathPattern=volumeHelpers` (17/17)
- [x] Manual: open App Configs with `hasPersistentData` on a captain build that includes #2440
- [x] Type a Label used by another app → yellow warning lists other app names
- [x] Label still free-text; host-path toggle unchanged
- [x] Older captain without volumes API: no toast, form usable

<img width="2532" height="984" alt="Screenshot 2026-07-27 at 14 02 03@2x" src="https://github.com/user-attachments/assets/7f7df187-9e00-49fd-9cb1-c5af04ec7ac5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an API-backed volume inventory used by the app configuration UI.
  - Shows a warning when a persistent directory/volume is already in use by other applications.

- **Bug Fixes**
  - Prevented volume inventory state updates after leaving the app details view.
  - Improved persistent volume resolution and compatibility with legacy volume names.

- **Documentation**
  - Added new localization strings for the “volume already in use” warning (multiple languages).

- **Tests**
  - Added unit and integration-style tests for volume resolution, conflict detection, and localized warning formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->