### PR TITLE
feat(app-configs): warn when persistent volume label is used by other apps

### DIFF
--- a/src/containers/apps/appDetails/AppConfigs.tsx
+++ b/src/containers/apps/appDetails/AppConfigs.tsx
@@ -1,16 +1,26 @@
 import { EditFilled, EditOutlined, InfoCircleOutlined } from '@ant-design/icons'
-import { Button, Col, Input, Row, Switch, Tag, Tooltip } from 'antd'
+import { Alert, Button, Col, Input, Row, Switch, Tag, Tooltip } from 'antd'
 import { Component, Fragment } from 'react'
 import { IHashMapGeneric } from '../../../models/IHashMapGeneric'
 import { localize } from '../../../utils/Language'
 import Utils from '../../../utils/Utils'
+import {
+    formatLocalized,
+    getOtherAppsUsingVolumeLabel,
+    VolumeUsageIndex,
+} from '../../../utils/volumeHelpers'
 import CodeEdit from '../../global/CodeEdit'
 import NewTabLink from '../../global/NewTabLink'
 import { IAppEnvVar } from '../AppDefinition'
 import { AppDetailsTabProps } from './AppDetails'
 
+export interface AppConfigsProps extends AppDetailsTabProps {
+    /** physicalVolumeName → app names; from getAllApps() via AppDetails */
+    volumeUsageIndex: VolumeUsageIndex
+}
+
 export default class AppConfigs extends Component<
-    AppDetailsTabProps,
+    AppConfigsProps,
     {
         dummyVar: undefined
         tagsEditMode: boolean
@@ -248,128 +258,166 @@ export default class AppConfigs extends Component<
 
     createVolRows() {
         const self = this
-        const volumes = this.props.apiData.appDefinition.volumes || []
+        const app = this.props.apiData.appDefinition
+        const volumes = app.volumes || []
         return volumes.map((value, index) => {
-            return (
-                <Row style={{ paddingBottom: 12 }} key={`${index}`}>
-                    <Col span={8}>
-                        <Input
-                            addonBefore={localize(
-                                'apps.app_config_vol_path',
-                                'Path in App'
-                            )}
-                            spellCheck={false}
-                            autoCorrect="off"
-                            autoComplete="off"
-                            autoCapitalize="off"
-                            className="code-input"
-                            placeholder="/var/www/html"
-                            value={value.containerPath}
-                            type="text"
-                            onChange={(e) => {
-                                const newApiData = Utils.copyObject(
-                                    self.props.apiData
-                                )
-                                newApiData.appDefinition.volumes[
-                                    index
-                                ].containerPath = e.target.value
-                                self.props.updateApiData(newApiData)
-                            }}
-                        />
-                    </Col>
-                    <Col
-                        style={{ paddingLeft: 12 }}
-                        span={8}
-                        className={value.hostPath ? 'hide-on-demand' : ''}
-                    >
-                        <Input
-                            addonBefore={localize(
-                                'apps.app_config_vol_label',
-                                'Label'
-                            )}
-                            spellCheck={false}
-                            autoCorrect="off"
-                            autoComplete="off"
-                            autoCapitalize="off"
-                            className="code-input"
-                            placeholder="some-name"
-                            value={value.volumeName}
-                            onChange={(e) => {
-                                const newApiData = Utils.copyObject(
-                                    self.props.apiData
-                                )
-                                newApiData.appDefinition.volumes[
-                                    index
-                                ].volumeName = e.target.value
-                                self.props.updateApiData(newApiData)
-                            }}
-                        />
-                    </Col>
+            // Bind mounts: Label is hidden; do not warn on volume sharing
+            // even if residual volumeName remains after toggling host path.
+            const otherApps = value.hostPath
+                ? []
+                : getOtherAppsUsingVolumeLabel(
+                      value.volumeName || '',
+                      app.isLegacyAppName,
+                      app.appName,
+                      self.props.volumeUsageIndex || {}
+                  )
 
-                    <Col
-                        style={{ paddingLeft: 12 }}
-                        span={8}
-                        className={!value.hostPath ? 'hide-on-demand' : ''}
+            return (
+                <div key={`${index}`}>
+                    <Row
+                        style={{
+                            paddingBottom: otherApps.length ? 4 : 12,
+                        }}
                     >
-                        <Tooltip
-                            title={localize(
-                                'apps.app_config_vol_host_path_hint',
-                                'IMPORTANT: Ensure Host Path exists before assigning it here'
-                            )}
-                        >
+                        <Col span={8}>
                             <Input
                                 addonBefore={localize(
-                                    'apps.app_config_vol_host_path',
-                                    'Path on Host'
+                                    'apps.app_config_vol_path',
+                                    'Path in App'
                                 )}
                                 spellCheck={false}
                                 autoCorrect="off"
                                 autoComplete="off"
                                 autoCapitalize="off"
                                 className="code-input"
-                                placeholder="/host/path/exists"
-                                value={value.hostPath}
+                                placeholder="/var/www/html"
+                                value={value.containerPath}
+                                type="text"
                                 onChange={(e) => {
                                     const newApiData = Utils.copyObject(
                                         self.props.apiData
                                     )
                                     newApiData.appDefinition.volumes[
                                         index
-                                    ].hostPath = e.target.value
+                                    ].containerPath = e.target.value
                                     self.props.updateApiData(newApiData)
                                 }}
                             />
-                        </Tooltip>
-                    </Col>
-                    <Col style={{ paddingLeft: 12 }} span={8}>
-                        <Button
-                            type="dashed"
-                            onClick={() => {
-                                const newApiData = Utils.copyObject(
-                                    self.props.apiData
-                                )
-                                newApiData.appDefinition.volumes[
-                                    index
-                                ].hostPath = newApiData.appDefinition.volumes[
-                                    index
-                                ].hostPath
-                                    ? ''
-                                    : '/'
-                                self.props.updateApiData(newApiData)
-                            }}
+                        </Col>
+                        <Col
+                            style={{ paddingLeft: 12 }}
+                            span={8}
+                            className={value.hostPath ? 'hide-on-demand' : ''}
                         >
-                            {value.hostPath
-                                ? localize(
-                                      'apps.app_config_vol_manage_path',
-                                      'Let CapRover manage path'
-                                  )
-                                : localize(
-                                      'apps.app_config_vol_set_path',
-                                      'Set specific host path'
-                                  )}
-                        </Button>
-                    </Col>
-                </Row>
+                            <Input
+                                addonBefore={localize(
+                                    'apps.app_config_vol_label',
+                                    'Label'
+                                )}
+                                spellCheck={false}
+                                autoCorrect="off"
+                                autoComplete="off"
+                                autoCapitalize="off"
+                                className="code-input"
+                                placeholder="some-name"
+                                value={value.volumeName}
+                                onChange={(e) => {
+                                    const newApiData = Utils.copyObject(
+                                        self.props.apiData
+                                    )
+                                    newApiData.appDefinition.volumes[
+                                        index
+                                    ].volumeName = e.target.value
+                                    self.props.updateApiData(newApiData)
+                                }}
+                            />
+                        </Col>
+
+                        <Col
+                            style={{ paddingLeft: 12 }}
+                            span={8}
+                            className={!value.hostPath ? 'hide-on-demand' : ''}
+                        >
+                            <Tooltip
+                                title={localize(
+                                    'apps.app_config_vol_host_path_hint',
+                                    'IMPORTANT: Ensure Host Path exists before assigning it here'
+                                )}
+                            >
+                                <Input
+                                    addonBefore={localize(
+                                        'apps.app_config_vol_host_path',
+                                        'Path on Host'
+                                    )}
+                                    spellCheck={false}
+                                    autoCorrect="off"
+                                    autoComplete="off"
+                                    autoCapitalize="off"
+                                    className="code-input"
+                                    placeholder="/host/path/exists"
+                                    value={value.hostPath}
+                                    onChange={(e) => {
+                                        const newApiData = Utils.copyObject(
+                                            self.props.apiData
+                                        )
+                                        newApiData.appDefinition.volumes[
+                                            index
+                                        ].hostPath = e.target.value
+                                        self.props.updateApiData(newApiData)
+                                    }}
+                                />
+                            </Tooltip>
+                        </Col>
+                        <Col style={{ paddingLeft: 12 }} span={8}>
+                            <Button
+                                type="dashed"
+                                onClick={() => {
+                                    const newApiData = Utils.copyObject(
+                                        self.props.apiData
+                                    )
+                                    newApiData.appDefinition.volumes[
+                                        index
+                                    ].hostPath = newApiData.appDefinition
+                                        .volumes[index].hostPath
+                                        ? ''
+                                        : '/'
+                                    self.props.updateApiData(newApiData)
+                                }}
+                            >
+                                {value.hostPath
+                                    ? localize(
+                                          'apps.app_config_vol_manage_path',
+                                          'Let CapRover manage path'
+                                      )
+                                    : localize(
+                                          'apps.app_config_vol_set_path',
+                                          'Set specific host path'
+                                      )}
+                            </Button>
+                        </Col>
+                    </Row>
+                    {otherApps.length > 0 ? (
+                        <Row style={{ paddingBottom: 12 }}>
+                            <Col span={24}>
+                                <Alert
+                                    type="warning"
+                                    showIcon={true}
+                                    message={formatLocalized(
+                                        localize(
+                                            'apps.app_config_vol_in_use_warning',
+                                            'This volume is already used by other application(s): %s'
+                                        ),
+                                        otherApps.join(', ')
+                                    )}
+                                    description={localize(
+                                        'apps.app_config_vol_in_use_warning_desc',
+                                        'You can ignore this warning if you intentionally share this volume across applications.'
+                                    )}
+                                />
+                            </Col>
+                        </Row>
+                    ) : undefined}
+                </div>
             )
         })
     }

--- a/src/containers/apps/appDetails/AppDetails.tsx
+++ b/src/containers/apps/appDetails/AppDetails.tsx
@@ -34,6 +34,10 @@ import ProjectDefinition from '../../../models/ProjectDefinition'
 import { localize } from '../../../utils/Language'
 import Toaster from '../../../utils/Toaster'
 import Utils from '../../../utils/Utils'
+import {
+    buildVolumeUsageIndex,
+    VolumeUsageIndex,
+} from '../../../utils/volumeHelpers'
 import ApiComponent from '../../global/ApiComponent'
 import CenteredSpinner from '../../global/CenteredSpinner'
 import ClickableLink from '../../global/ClickableLink'
@@ -83,6 +87,7 @@ class AppDetails extends ApiComponent<
         apiData: SingleAppApiData | undefined
         activeTabKey: string
         renderCounterForAffixBug: number
+        volumeUsageIndex: VolumeUsageIndex
         editAppDataForModal:
             | {
                   appName: string
@@ -106,6 +111,7 @@ class AppDetails extends ApiComponent<
             renderCounterForAffixBug: 0,
             apiData: undefined,
             editAppDataForModal: undefined,
+            volumeUsageIndex: {},
         }
     }
 
@@ -397,7 +403,15 @@ class AppDetails extends ApiComponent<
                                             )}
                                         </span>
                                     ),
-                                    children: <AppConfigs {...tabProps} />,
+                                    children: (
+                                        <AppConfigs
+                                            {...tabProps}
+                                            volumeUsageIndex={
+                                                this.state.volumeUsageIndex ||
+                                                {}
+                                            }
+                                        />
+                                    ),
                                 },
                                 {
                                     key: DEPLOYMENT,
@@ -705,16 +719,17 @@ class AppDetails extends ApiComponent<
                 const getAppsResp = dataReturns[0]
                 const projects = dataReturns[1].projects || []
                 const goAccessInfo = dataReturns[2]
+                const appDefinitions = getAppsResp.appDefinitions || []
 
-                for (
-                    let index = 0;
-                    index < getAppsResp.appDefinitions.length;
-                    index++
-                ) {
-                    const element = getAppsResp.appDefinitions[index]
+                // Build index from FULL list before filtering to current app
+                const volumeUsageIndex = buildVolumeUsageIndex(appDefinitions)
+
+                for (let index = 0; index < appDefinitions.length; index++) {
+                    const element = appDefinitions[index]
                     if (element.appName === self.props.match.params.appName) {
                         self.setState({
                             isLoading: false,
+                            volumeUsageIndex,
                             apiData: {
                                 projects: projects,
                                 appDefinition: element,

--- a/src/locales/ar-EG.json
+++ b/src/locales/ar-EG.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "الأدلة المستمرة",
     "apps.app_config_vol_host_path": "المسار على الخادم",
     "apps.app_config_vol_host_path_hint": "مهم: تأكد من وجود المسار على الخادم قبل تعيينه هنا",
+    "apps.app_config_vol_in_use_warning": "هذا المجلد مستخدم بالفعل بواسطة تطبيق(ات) أخرى: %s",
+    "apps.app_config_vol_in_use_warning_desc": "يمكنك تجاهل هذا التحذير إذا كنت تشارك هذا المجلد عمدًا بين التطبيقات.",
     "apps.app_config_vol_label": "العلامة",
     "apps.app_config_vol_manage_path": "دع CapRover يدير المسار",
     "apps.app_config_vol_no_directories": "حاليًا، لا يمتلك هذا التطبيق أي أدلة مستمرة.",

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Persistente Verzeichnisse",
     "apps.app_config_vol_host_path": "Hostpfad",
     "apps.app_config_vol_host_path_hint": "WICHTIG: Stellen Sie sicher, dass der Hostpfad vorhanden ist, bevor Sie ihn hier zuweisen",
+    "apps.app_config_vol_in_use_warning": "Dieses Volume wird bereits von anderen Anwendung(en) verwendet: %s",
+    "apps.app_config_vol_in_use_warning_desc": "Sie können diese Warnung ignorieren, wenn Sie dieses Volume absichtlich über Anwendungen hinweg teilen.",
     "apps.app_config_vol_label": "Bezeichnung",
     "apps.app_config_vol_manage_path": "Lassen Sie CapRover den Pfad verwalten",
     "apps.app_config_vol_no_directories": "Derzeit hat diese App keine persistenten Verzeichnisse.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Persistent Directories",
     "apps.app_config_vol_host_path": "Path on Host",
     "apps.app_config_vol_host_path_hint": "IMPORTANT: Ensure Host Path exists before assigning it here",
+    "apps.app_config_vol_in_use_warning": "This volume is already used by other application(s): %s",
+    "apps.app_config_vol_in_use_warning_desc": "You can ignore this warning if you intentionally share this volume across applications.",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Let CapRover manage path",
     "apps.app_config_vol_no_directories": "Currently, this app does not have any persistent directories.",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Directorios Persistentes",
     "apps.app_config_vol_host_path": "Ruta en el Host",
     "apps.app_config_vol_host_path_hint": "IMPORTANTE: Asegúrese de que la Ruta del Host exista antes de asignarla aquí",
+    "apps.app_config_vol_in_use_warning": "Este volumen ya está siendo usado por otra(s) aplicación(es): %s",
+    "apps.app_config_vol_in_use_warning_desc": "Puede ignorar esta advertencia si comparte intencionalmente este volumen entre aplicaciones.",
     "apps.app_config_vol_label": "Etiqueta",
     "apps.app_config_vol_manage_path": "Dejar que CapRover administre la ruta",
     "apps.app_config_vol_no_directories": "Actualmente, esta app no tiene ningún directorio persistente.",

--- a/src/locales/fa-IR.json
+++ b/src/locales/fa-IR.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "دایرکتوری‌های دائمی",
     "apps.app_config_vol_host_path": "مسیر روی میزبان",
     "apps.app_config_vol_host_path_hint": "مهم: قبل از اختصاص دادن آن در اینجا، اطمینان حاصل کنید که مسیر میزبان وجود دارد",
+    "apps.app_config_vol_in_use_warning": "این volume قبلاً توسط برنامه(های) دیگر استفاده می‌شود: %s",
+    "apps.app_config_vol_in_use_warning_desc": "اگر عمداً این volume را بین برنامه‌ها به اشتراک می‌گذارید، می‌توانید این هشدار را نادیده بگیرید.",
     "apps.app_config_vol_label": "برچسب",
     "apps.app_config_vol_manage_path": "مدیریت مسیر توسط کپروور",
     "apps.app_config_vol_no_directories": "در حال حاضر، این برنامه هیچ دایرکتوری دائمی ندارد.",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Répertoires Persistants",
     "apps.app_config_vol_host_path": "Chemin sur l'Hôte",
     "apps.app_config_vol_host_path_hint": "IMPORTANT : Assurez-vous que le Chemin Hôte existe avant de l'assigner ici",
+    "apps.app_config_vol_in_use_warning": "Ce volume est déjà utilisé par d'autre(s) application(s) : %s",
+    "apps.app_config_vol_in_use_warning_desc": "Vous pouvez ignorer cet avertissement si vous partagez intentionnellement ce volume entre applications.",
     "apps.app_config_vol_label": "Libellé",
     "apps.app_config_vol_manage_path": "Laisser CapRover gérer le chemin",
     "apps.app_config_vol_no_directories": "Actuellement, cette app n'a pas de répertoires persistants.",

--- a/src/locales/hr-HR.json
+++ b/src/locales/hr-HR.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Trajni direktoriji",
     "apps.app_config_vol_host_path": "Putanja na hostu",
     "apps.app_config_vol_host_path_hint": "VAŽNO: Provjerite postoji li putanja na hostu prije nego što je ovdje dodijelite",
+    "apps.app_config_vol_in_use_warning": "Ovaj volume već koriste druge aplikacije: %s",
+    "apps.app_config_vol_in_use_warning_desc": "Možete zanemariti ovo upozorenje ako namjerno dijelite ovaj volume između aplikacija.",
     "apps.app_config_vol_label": "Oznaka",
     "apps.app_config_vol_manage_path": "Prepusti CapRoveru upravljanje putanjom",
     "apps.app_config_vol_no_directories": "Trenutno ova aplikacija nema trajne direktorije.",

--- a/src/locales/id-ID.json
+++ b/src/locales/id-ID.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Direktori Persisten",
     "apps.app_config_vol_host_path": "Jalur di Host",
     "apps.app_config_vol_host_path_hint": "PENTING: Pastikan Jalur Host ada sebelum menetapkannya di sini",
+    "apps.app_config_vol_in_use_warning": "Volume ini sudah digunakan oleh aplikasi lain: %s",
+    "apps.app_config_vol_in_use_warning_desc": "Anda dapat mengabaikan peringatan ini jika memang sengaja berbagi volume ini antar aplikasi.",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Biarkan CapRover mengelola jalur",
     "apps.app_config_vol_no_directories": "Saat ini, aplikasi ini tidak memiliki direktori persisten.",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "永続ディレクトリ",
     "apps.app_config_vol_host_path": "ホスト上のパス",
     "apps.app_config_vol_host_path_hint": "重要：ここで割り当てる前に、ホストパスが存在することを確認してください",
+    "apps.app_config_vol_in_use_warning": "このボリュームは既に他のアプリケーションで使用されています: %s",
+    "apps.app_config_vol_in_use_warning_desc": "アプリケーション間でこのボリュームを意図的に共有している場合は、この警告を無視してかまいません。",
     "apps.app_config_vol_label": "ラベル",
     "apps.app_config_vol_manage_path": "CapRoverにパスを管理させる",
     "apps.app_config_vol_no_directories": "現在、このアプリには永続ディレクトリがありません。",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "영구 디렉터리",
     "apps.app_config_vol_host_path": "호스트 경로",
     "apps.app_config_vol_host_path_hint": "중요: 여기에 지정하기 전에 호스트 경로가 존재하는지 확인하세요",
+    "apps.app_config_vol_in_use_warning": "이 볼륨은 이미 다른 애플리케이션에서 사용 중입니다: %s",
+    "apps.app_config_vol_in_use_warning_desc": "애플리케이션 간에 이 볼륨을 의도적으로 공유하는 경우 이 경고를 무시해도 됩니다.",
     "apps.app_config_vol_label": "레이블",
     "apps.app_config_vol_manage_path": "CapRover가 경로 관리",
     "apps.app_config_vol_no_directories": "현재 이 앱에는 영구 디렉터리가 없습니다.",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -54,7 +54,7 @@
     "apps.app_config_vol_host_path": "Pad op host",
     "apps.app_config_vol_host_path_hint": "BELANGRIJK: Zorg ervoor dat het hostpad bestaat voordat je het hier toewijst",
     "apps.app_config_vol_in_use_warning": "Dit volume wordt al gebruikt door andere applicatie(s): %s",
-    "apps.app_config_vol_in_use_warning_desc": "U kunt deze waarschuwing negeren als u dit volume opzettelijk deelt tussen applicaties.",
+    "apps.app_config_vol_in_use_warning_desc": "Je kunt deze waarschuwing negeren als je dit volume opzettelijk deelt tussen applicaties.",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Laat CapRover het pad beheren",
     "apps.app_config_vol_no_directories": "Momenteel heeft deze app geen persistente mappen.",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Persistente mappen",
     "apps.app_config_vol_host_path": "Pad op host",
     "apps.app_config_vol_host_path_hint": "BELANGRIJK: Zorg ervoor dat het hostpad bestaat voordat je het hier toewijst",
+    "apps.app_config_vol_in_use_warning": "Dit volume wordt al gebruikt door andere applicatie(s): %s",
+    "apps.app_config_vol_in_use_warning_desc": "U kunt deze waarschuwing negeren als u dit volume opzettelijk deelt tussen applicaties.",
     "apps.app_config_vol_label": "Label",
     "apps.app_config_vol_manage_path": "Laat CapRover het pad beheren",
     "apps.app_config_vol_no_directories": "Momenteel heeft deze app geen persistente mappen.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Diretórios Persistentes",
     "apps.app_config_vol_host_path": "Caminho no Host",
     "apps.app_config_vol_host_path_hint": "IMPORTANTE: Garanta que o Caminho do Host exista antes de atribuí-lo aqui",
+    "apps.app_config_vol_in_use_warning": "Este volume já está sendo usado por outro(s) aplicativo(s): %s",
+    "apps.app_config_vol_in_use_warning_desc": "Você pode ignorar este aviso se compartilhar intencionalmente este volume entre aplicativos.",
     "apps.app_config_vol_label": "Rótulo",
     "apps.app_config_vol_manage_path": "Permitir que o CapRover gerencie o caminho",
     "apps.app_config_vol_no_directories": "Atualmente, este app não possui diretórios persistentes.",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Постоянные volume",
     "apps.app_config_vol_host_path": "Путь на хосте",
     "apps.app_config_vol_host_path_hint": "ВАЖНО: убедитесь, что путь на хосте существует",
+    "apps.app_config_vol_in_use_warning": "Этот volume уже используется другим приложением(ями): %s",
+    "apps.app_config_vol_in_use_warning_desc": "Вы можете игнорировать это предупреждение, если намеренно используете этот volume совместно несколькими приложениями.",
     "apps.app_config_vol_label": "Метка",
     "apps.app_config_vol_manage_path": "Разрешить CapRover управлять путём",
     "apps.app_config_vol_no_directories": "У этого приложения пока нет docker volumes.",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Beständiga mappar",
     "apps.app_config_vol_host_path": "Sökväg på värd",
     "apps.app_config_vol_host_path_hint": "VIKTIGT: Se till att värdvägen finns innan du tilldelar den här",
+    "apps.app_config_vol_in_use_warning": "Denna volym används redan av annan applikation/applikationer: %s",
+    "apps.app_config_vol_in_use_warning_desc": "Du kan ignorera den här varningen om du avsiktligt delar den här volymen mellan applikationer.",
     "apps.app_config_vol_label": "Etikett",
     "apps.app_config_vol_manage_path": "Låt CapRover hantera sökvägen",
     "apps.app_config_vol_no_directories": "För närvarande har denna app inga beständiga mappar.",

--- a/src/locales/tr-TR.json
+++ b/src/locales/tr-TR.json
@@ -54,7 +54,7 @@
     "apps.app_config_vol_host_path": "Ev Sahibi Yolu",
     "apps.app_config_vol_host_path_hint": "ÖNEMLİ: Buraya atama yapmadan önce Ev Sahibi Yolu'nun var olduğundan emin olun",
     "apps.app_config_vol_in_use_warning": "Bu birim zaten diğer uygulama(lar) tarafından kullanılıyor: %s",
-    "apps.app_config_vol_in_use_warning_desc": "Bu volume'u uygulamalar arasında bilerek paylaşıyorsanız bu uyarıyı yok sayabilirsiniz.",
+    "apps.app_config_vol_in_use_warning_desc": "Bu birimi uygulamalar arasında bilerek paylaşıyorsanız bu uyarıyı yok sayabilirsiniz.",
     "apps.app_config_vol_label": "Etiket",
     "apps.app_config_vol_manage_path": "Yolu CapRover yönetir",
     "apps.app_config_vol_no_directories": "Şu anda, bu uygulamada herhangi bir kalıcı dizin yok.",

--- a/src/locales/tr-TR.json
+++ b/src/locales/tr-TR.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "Kalıcı Dizinler",
     "apps.app_config_vol_host_path": "Ev Sahibi Yolu",
     "apps.app_config_vol_host_path_hint": "ÖNEMLİ: Buraya atama yapmadan önce Ev Sahibi Yolu'nun var olduğundan emin olun",
+    "apps.app_config_vol_in_use_warning": "Bu birim zaten diğer uygulama(lar) tarafından kullanılıyor: %s",
+    "apps.app_config_vol_in_use_warning_desc": "Bu volume'u uygulamalar arasında bilerek paylaşıyorsanız bu uyarıyı yok sayabilirsiniz.",
     "apps.app_config_vol_label": "Etiket",
     "apps.app_config_vol_manage_path": "Yolu CapRover yönetir",
     "apps.app_config_vol_no_directories": "Şu anda, bu uygulamada herhangi bir kalıcı dizin yok.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -53,6 +53,8 @@
     "apps.app_config_vol_directories": "持久目录",
     "apps.app_config_vol_host_path": "主机路径",
     "apps.app_config_vol_host_path_hint": "重要：分配路径之前，请确保主机路径存在",
+    "apps.app_config_vol_in_use_warning": "此卷已被其他应用使用：%s",
+    "apps.app_config_vol_in_use_warning_desc": "如果您有意在多个应用之间共享此卷，可以忽略此警告。",
     "apps.app_config_vol_label": "标签",
     "apps.app_config_vol_manage_path": "让 CapRover 管理路径",
     "apps.app_config_vol_no_directories": "当前，此应用没有任何持久目录。",

--- a/src/utils/volumeHelpers.test.ts
+++ b/src/utils/volumeHelpers.test.ts
@@ -151,12 +151,10 @@ describe('buildVolumeUsageIndex', () => {
 describe('getOtherAppsUsingVolumeLabel', () => {
     it('returns empty array when label is empty', () => {
         const index = { data: ['other'] }
-        expect(
-            getOtherAppsUsingVolumeLabel('', false, 'me', index)
-        ).toEqual([])
-        expect(
-            getOtherAppsUsingVolumeLabel('   ', false, 'me', index)
-        ).toEqual([])
+        expect(getOtherAppsUsingVolumeLabel('', false, 'me', index)).toEqual([])
+        expect(getOtherAppsUsingVolumeLabel('   ', false, 'me', index)).toEqual(
+            []
+        )
     })
 
     it('returns other modern apps using the same label', () => {
@@ -166,12 +164,7 @@ describe('getOtherAppsUsingVolumeLabel', () => {
         ]
         const index = buildVolumeUsageIndex(apps)
         expect(
-            getOtherAppsUsingVolumeLabel(
-                'shared-db',
-                false,
-                'api',
-                index
-            )
+            getOtherAppsUsingVolumeLabel('shared-db', false, 'api', index)
         ).toEqual(['worker'])
     })
 
@@ -203,20 +196,10 @@ describe('getOtherAppsUsingVolumeLabel', () => {
             data: ['modern-app'],
         })
         expect(
-            getOtherAppsUsingVolumeLabel(
-                'data',
-                true,
-                'legacy-app',
-                index
-            )
+            getOtherAppsUsingVolumeLabel('data', true, 'legacy-app', index)
         ).toEqual([])
         expect(
-            getOtherAppsUsingVolumeLabel(
-                'data',
-                false,
-                'modern-app',
-                index
-            )
+            getOtherAppsUsingVolumeLabel('data', false, 'modern-app', index)
         ).toEqual([])
     })
 
@@ -244,19 +227,14 @@ describe('getOtherAppsUsingVolumeLabel', () => {
         ]
         const index = buildVolumeUsageIndex(apps)
         expect(
-            getOtherAppsUsingVolumeLabel(
-                'data',
-                true,
-                'legacy-app',
-                index
-            )
+            getOtherAppsUsingVolumeLabel('data', true, 'legacy-app', index)
         ).toEqual(['other-legacy'])
     })
 
     it('returns empty when index is empty', () => {
-        expect(
-            getOtherAppsUsingVolumeLabel('data', false, 'me', {})
-        ).toEqual([])
+        expect(getOtherAppsUsingVolumeLabel('data', false, 'me', {})).toEqual(
+            []
+        )
     })
 })
 

--- a/src/utils/volumeHelpers.test.ts
+++ b/src/utils/volumeHelpers.test.ts
@@ -1,0 +1,278 @@
+import { IAppDef } from '../containers/apps/AppDefinition'
+import {
+    buildVolumeUsageIndex,
+    formatLocalized,
+    getOtherAppsUsingVolumeLabel,
+    resolvePhysicalVolumeName,
+} from './volumeHelpers'
+
+function makeApp(
+    appName: string,
+    options: {
+        isLegacyAppName?: boolean
+        volumes?: Array<{
+            containerPath?: string
+            volumeName?: string
+            hostPath?: string
+        }>
+    } = {}
+): IAppDef {
+    return {
+        appName,
+        isLegacyAppName: options.isLegacyAppName,
+        volumes: (options.volumes || []).map((v) => ({
+            containerPath: v.containerPath || '/data',
+            volumeName: v.volumeName,
+            hostPath: v.hostPath,
+        })),
+        // Minimal IAppDef fields required by the type; unused by helpers
+        deployedVersion: 0,
+        notExposeAsWebApp: false,
+        hasPersistentData: true,
+        hasDefaultSubDomainSsl: false,
+        containerHttpPort: 80,
+        captainDefinitionRelativeFilePath: 'captain-definition',
+        forceSsl: false,
+        websocketSupport: false,
+        instanceCount: 1,
+        networks: [],
+        customDomain: [],
+        ports: [],
+        envVars: [],
+        versions: [],
+    }
+}
+
+describe('resolvePhysicalVolumeName', () => {
+    it('returns empty string for empty or whitespace-only label', () => {
+        expect(resolvePhysicalVolumeName('', false)).toBe('')
+        expect(resolvePhysicalVolumeName('   ', false)).toBe('')
+        expect(resolvePhysicalVolumeName('', true)).toBe('')
+        expect(resolvePhysicalVolumeName(undefined as any, false)).toBe('')
+    })
+
+    it('returns label as-is for modern apps', () => {
+        expect(resolvePhysicalVolumeName('my-data', false)).toBe('my-data')
+        expect(resolvePhysicalVolumeName('my-data', undefined)).toBe('my-data')
+        expect(resolvePhysicalVolumeName('  my-data  ', false)).toBe('my-data')
+    })
+
+    it('prefixes namespace for legacy apps with default captain namespace', () => {
+        expect(resolvePhysicalVolumeName('data', true)).toBe('captain--data')
+        expect(resolvePhysicalVolumeName('  data  ', true)).toBe(
+            'captain--data'
+        )
+    })
+
+    it('uses custom namespace when provided for legacy apps', () => {
+        expect(resolvePhysicalVolumeName('data', true, 'custom')).toBe(
+            'custom--data'
+        )
+    })
+
+    it('does not rewrite modern labels that look like legacy physical names', () => {
+        // Theoretical: API normally forbids `--` in volume names
+        expect(resolvePhysicalVolumeName('captain--data', false)).toBe(
+            'captain--data'
+        )
+    })
+})
+
+describe('buildVolumeUsageIndex', () => {
+    it('returns empty object for empty app list', () => {
+        expect(buildVolumeUsageIndex([])).toEqual({})
+    })
+
+    it('skips apps without appName', () => {
+        const app = makeApp('', { volumes: [{ volumeName: 'data' }] })
+        app.appName = undefined
+        expect(buildVolumeUsageIndex([app])).toEqual({})
+    })
+
+    it('indexes modern labels as-is', () => {
+        const apps = [
+            makeApp('api', { volumes: [{ volumeName: 'shared-db' }] }),
+            makeApp('worker', { volumes: [{ volumeName: 'shared-db' }] }),
+        ]
+        expect(buildVolumeUsageIndex(apps)).toEqual({
+            'shared-db': ['api', 'worker'],
+        })
+    })
+
+    it('indexes legacy labels with captain-- prefix using each app flag', () => {
+        const apps = [
+            makeApp('old-app', {
+                isLegacyAppName: true,
+                volumes: [{ volumeName: 'data' }],
+            }),
+        ]
+        expect(buildVolumeUsageIndex(apps)).toEqual({
+            'captain--data': ['old-app'],
+        })
+    })
+
+    it('excludes hostPath bind mounts even with residual volumeName', () => {
+        const apps = [
+            makeApp('api', {
+                volumes: [
+                    {
+                        volumeName: 'should-ignore',
+                        hostPath: '/host/path',
+                    },
+                    { volumeName: 'kept' },
+                ],
+            }),
+        ]
+        expect(buildVolumeUsageIndex(apps)).toEqual({
+            kept: ['api'],
+        })
+    })
+
+    it('skips empty volume labels', () => {
+        const apps = [
+            makeApp('api', {
+                volumes: [{ volumeName: '' }, { volumeName: '   ' }],
+            }),
+        ]
+        expect(buildVolumeUsageIndex(apps)).toEqual({})
+    })
+
+    it('sorts unique app names', () => {
+        const apps = [
+            makeApp('zeta', { volumes: [{ volumeName: 'v' }] }),
+            makeApp('alpha', { volumes: [{ volumeName: 'v' }] }),
+            makeApp('zeta', { volumes: [{ volumeName: 'v' }] }),
+        ]
+        // Two entries with same appName still unique via Set
+        expect(buildVolumeUsageIndex(apps)['v']).toEqual(['alpha', 'zeta'])
+    })
+})
+
+describe('getOtherAppsUsingVolumeLabel', () => {
+    it('returns empty array when label is empty', () => {
+        const index = { data: ['other'] }
+        expect(
+            getOtherAppsUsingVolumeLabel('', false, 'me', index)
+        ).toEqual([])
+        expect(
+            getOtherAppsUsingVolumeLabel('   ', false, 'me', index)
+        ).toEqual([])
+    })
+
+    it('returns other modern apps using the same label', () => {
+        const apps = [
+            makeApp('api', { volumes: [{ volumeName: 'shared-db' }] }),
+            makeApp('worker', { volumes: [{ volumeName: 'shared-db' }] }),
+        ]
+        const index = buildVolumeUsageIndex(apps)
+        expect(
+            getOtherAppsUsingVolumeLabel(
+                'shared-db',
+                false,
+                'api',
+                index
+            )
+        ).toEqual(['worker'])
+    })
+
+    it('excludes the current app from the list', () => {
+        const apps = [
+            makeApp('only-mine', { volumes: [{ volumeName: 'mine' }] }),
+        ]
+        const index = buildVolumeUsageIndex(apps)
+        expect(
+            getOtherAppsUsingVolumeLabel('mine', false, 'only-mine', index)
+        ).toEqual([])
+    })
+
+    it('critical: mixed-era same logical label does not collide', () => {
+        // Legacy "data" → captain--data; modern "data" → data
+        const apps = [
+            makeApp('legacy-app', {
+                isLegacyAppName: true,
+                volumes: [{ volumeName: 'data' }],
+            }),
+            makeApp('modern-app', {
+                isLegacyAppName: false,
+                volumes: [{ volumeName: 'data' }],
+            }),
+        ]
+        const index = buildVolumeUsageIndex(apps)
+        expect(index).toEqual({
+            'captain--data': ['legacy-app'],
+            data: ['modern-app'],
+        })
+        expect(
+            getOtherAppsUsingVolumeLabel(
+                'data',
+                true,
+                'legacy-app',
+                index
+            )
+        ).toEqual([])
+        expect(
+            getOtherAppsUsingVolumeLabel(
+                'data',
+                false,
+                'modern-app',
+                index
+            )
+        ).toEqual([])
+    })
+
+    it('warns when two modern apps share the same label', () => {
+        const apps = [
+            makeApp('a', { volumes: [{ volumeName: 'shared' }] }),
+            makeApp('b', { volumes: [{ volumeName: 'shared' }] }),
+        ]
+        const index = buildVolumeUsageIndex(apps)
+        expect(
+            getOtherAppsUsingVolumeLabel('shared', false, 'a', index)
+        ).toEqual(['b'])
+    })
+
+    it('resolves lookup with current app legacy flag against index', () => {
+        const apps = [
+            makeApp('legacy-app', {
+                isLegacyAppName: true,
+                volumes: [{ volumeName: 'data' }],
+            }),
+            makeApp('other-legacy', {
+                isLegacyAppName: true,
+                volumes: [{ volumeName: 'data' }],
+            }),
+        ]
+        const index = buildVolumeUsageIndex(apps)
+        expect(
+            getOtherAppsUsingVolumeLabel(
+                'data',
+                true,
+                'legacy-app',
+                index
+            )
+        ).toEqual(['other-legacy'])
+    })
+
+    it('returns empty when index is empty', () => {
+        expect(
+            getOtherAppsUsingVolumeLabel('data', false, 'me', {})
+        ).toEqual([])
+    })
+})
+
+describe('formatLocalized', () => {
+    it('replaces %s with the provided value', () => {
+        expect(
+            formatLocalized(
+                'This volume is already used by other application(s): %s',
+                'my-db, worker'
+            )
+        ).toBe(
+            'This volume is already used by other application(s): my-db, worker'
+        )
+    })
+
+    it('replaces all %s occurrences', () => {
+        expect(formatLocalized('%s and %s', 'a')).toBe('a and a')
+    })
+})

--- a/src/utils/volumeHelpers.ts
+++ b/src/utils/volumeHelpers.ts
@@ -1,0 +1,90 @@
+import { IAppDef } from '../containers/apps/AppDefinition'
+
+const DEFAULT_NAMESPACE = 'captain' // backend rootNameSpace; not exposed to UI
+
+/** physical Docker volume name → sorted unique CapRover app names */
+export type VolumeUsageIndex = Record<string, string[]>
+
+/**
+ * Resolve the physical Docker volume name from a logical label.
+ * Modern apps use the label as-is; legacy apps use `${namespace}--${label}`.
+ * Matches captain AppsDataStore.getVolumeName.
+ */
+export function resolvePhysicalVolumeName(
+    volumeName: string,
+    isLegacyAppName: boolean | undefined,
+    namespace: string = DEFAULT_NAMESPACE
+): string {
+    const label = (volumeName || '').trim()
+    if (!label) {
+        return ''
+    }
+    if (isLegacyAppName) {
+        return `${namespace}--${label}`
+    }
+    return label
+}
+
+/**
+ * Build an index of physical volume names to CapRover app names from app definitions.
+ * - Skips bind mounts (truthy hostPath), even if residual volumeName remains in draft UI.
+ * - Resolves each volume with that source app's isLegacyAppName.
+ */
+export function buildVolumeUsageIndex(apps: IAppDef[]): VolumeUsageIndex {
+    const map = new Map<string, Set<string>>()
+    for (const app of apps) {
+        const appName = app.appName
+        if (!appName) {
+            continue
+        }
+        for (const vol of app.volumes || []) {
+            // Treat truthy hostPath as bind mount for warning purposes even if
+            // volumeName is still non-empty in draft UI state.
+            if (vol.hostPath) {
+                continue
+            }
+            const physical = resolvePhysicalVolumeName(
+                vol.volumeName || '',
+                app.isLegacyAppName
+            )
+            if (!physical) {
+                continue
+            }
+            if (!map.has(physical)) {
+                map.set(physical, new Set())
+            }
+            map.get(physical)!.add(appName)
+        }
+    }
+    const out: VolumeUsageIndex = {}
+    map.forEach((names, key) => {
+        out[key] = Array.from(names).sort()
+    })
+    return out
+}
+
+/**
+ * Return CapRover app names (excluding currentAppName) that already use
+ * the physical Docker volume corresponding to the given logical label.
+ * Lookup resolves with the current app's isLegacyAppName.
+ */
+export function getOtherAppsUsingVolumeLabel(
+    volumeName: string,
+    isLegacyAppName: boolean | undefined,
+    currentAppName: string | undefined,
+    index: VolumeUsageIndex
+): string[] {
+    const physical = resolvePhysicalVolumeName(volumeName, isLegacyAppName)
+    if (!physical) {
+        return []
+    }
+    const users = index[physical] || []
+    return users.filter((name) => name !== currentAppName)
+}
+
+/**
+ * Replace a single `%s` placeholder in a localized template string.
+ */
+export function formatLocalized(template: string, value: string): string {
+    return template.split('%s').join(value)
+}


### PR DESCRIPTION
## Summary

- When editing **Persistent Directories** on App Configs, warn if the volume **Label** resolves to a Docker volume name already used by other CapRover apps.
- **Frontend-only**: derive conflicts from the existing `getAllApps()` / app-definitions response (already loaded on App Details). No new backend endpoint, no `getAllVolumes`, no captain inventory route.
- Warn-only (never blocks Save). Alert includes an intentional-share description.

## Screenshot
<img width="1940" height="333" alt="image" src="https://github.com/user-attachments/assets/88c85bda-4f20-4733-8c1a-1c0b1c3072d5" />

<img width="1832" height="253" alt="image" src="https://github.com/user-attachments/assets/609564b2-e49e-4f0f-9801-557854540223" />


### Supersedes PR #223 inventory approach

This PR **supersedes** the data/backend path in [#223](https://github.com/caprover/caprover-frontend/pull/223).

That produces the same warning inputs **without** another request, backend route, API contract, aggregation implementation, or backward-compatibility fallback.

**What we reuse from #223:** Alert presentation (`type="warning" showIcon`), padding, and i18n key naming for the primary message.  
**What we do not ship:** `GET /user/system/volumes/`, `ApiManager.getAllVolumes`, inventory DTOs, or AppConfigs self-fetch.

## Implementation

1. `src/utils/volumeHelpers.ts` — `buildVolumeUsageIndex`, `getOtherAppsUsingVolumeLabel`, `resolvePhysicalVolumeName`, `formatLocalized` (+ unit tests, including mixed-era same logical Label → no false positive).
2. `AppDetails.reFetchData` builds `volumeUsageIndex` from the **full** `appDefinitions` list before selecting the current app; passes index only into `AppConfigs`.
3. `AppConfigs` shows warning under volume rows when other apps share the physical name.
4. i18n: `apps.app_config_vol_in_use_warning` + `apps.app_config_vol_in_use_warning_desc` in all 16 locales (including `ja-JP`).

## Test plan

- [x] App without persistent data: no volume section / no warning path.
- [x] Unique Label → no alert.
- [x] Two modern apps share Label → alert lists the other app name(s).
- [x] Mixed-era same logical Label (`data` on legacy + modern) → **no** alert (`captain--data` ≠ `data`).
- [x] Switch row to host path (including residual Label in draft) → no alert.
- [x] Save still succeeds while warning is visible.
- [x] Locale switch (en-US / zh-CN / ja-JP) shows translated message + description.
- [x] `yarn test --watchAll=false --testPathPattern=volumeHelpers`
- [x] `yarn formatter` / `yarn tslint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added volume configuration guidance distinguishing bind mounts from managed volumes.
  - Added warnings when managed volumes are used by other applications, with support for intentional sharing.
  - Added localized warnings and guidance across supported languages.

- **Bug Fixes**
  - Improved volume name resolution and usage tracking across current and legacy application configurations.

- **Tests**
  - Added coverage for volume detection, filtering, deduplication, legacy handling, and localized messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->