### PR TITLE
Track one-click app template sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "@reduxjs/toolkit": "^2.8.2",
         "antd": "5.25.3",
         "axios": "^1.9.0",
-        "caprover-api": "^0.0.18",
+        "caprover-api": "^0.0.19",
         "classnames": "^2.2.6",
         "deep-equal": "^2.0.5",
         "moment": "^2.29.1",

--- a/src/containers/PageRoot.tsx
+++ b/src/containers/PageRoot.tsx
@@ -20,9 +20,7 @@ import Apps from './apps/Apps'
 import ProjectDetailsEdit from './apps/ProjectDetailsEdit'
 import AppDetails from './apps/appDetails/AppDetails'
 import DockerComposeEntry from './apps/compose/DockerComposeEntry'
-import OneClickAppSelector, {
-    TEMPLATE_ONE_CLICK_APP,
-} from './apps/oneclick/selector/OneClickAppSelector'
+import OneClickAppSelector from './apps/oneclick/selector/OneClickAppSelector'
 import TemplateInputPage from './apps/oneclick/template/TemplateInputPage'
 import OneClickAppConfigPage from './apps/oneclick/variables/OneClickAppConfigPage'
 import OneClickDeploymentPage from './apps/oneclick/variables/OneClickDeploymentPage'
@@ -325,7 +323,7 @@ class PageRoot extends ApiComponent<
                                     )}
                                 />
                                 <Route
-                                    path={`/apps/oneclick/input/${TEMPLATE_ONE_CLICK_APP}`}
+                                    path={`/apps/oneclick/templategenerator`}
                                     component={TemplateInputPage}
                                 />
                                 <Route

--- a/src/containers/apps/compose/DockerComposeEntry.tsx
+++ b/src/containers/apps/compose/DockerComposeEntry.tsx
@@ -8,8 +8,9 @@ import InputJsonifier from '../../global/InputJsonifier'
 import {
     DEPLOYMENT_QUERY_PARAM_APP_NAME,
     DEPLOYMENT_QUERY_PARAM_TEMPLATE,
+    DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME,
     DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
-} from '../oneclick/variables/OneClickAppConfigPage'
+} from '../oneclick/OneClickDeploymentConstants'
 
 export const TEMPLATE_ONE_CLICK_APP = 'TEMPLATE_ONE_CLICK_APP'
 export const ONE_CLICK_APP_STRINGIFIED_KEY = 'oneClickAppStringifiedData'
@@ -146,8 +147,8 @@ volumes:
         const templateStr = encodeURIComponent(JSON.stringify(template))
         const valuesArrayStr = encodeURIComponent(JSON.stringify([]))
         const appName = 'Docker Compose'
-
-        const deployUrl = `/apps/oneclick/deployment?${DEPLOYMENT_QUERY_PARAM_TEMPLATE}=${templateStr}&${DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY}=${valuesArrayStr}&${DEPLOYMENT_QUERY_PARAM_APP_NAME}=${appName}`
+        const templateName = 'DOCKER_COMPOSE'
+        const deployUrl = `/apps/oneclick/deployment?${DEPLOYMENT_QUERY_PARAM_TEMPLATE}=${templateStr}&${DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY}=${valuesArrayStr}&${DEPLOYMENT_QUERY_PARAM_APP_NAME}=${appName}&${DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME}=${templateName}`
         self.props.history.push(deployUrl)
     }
 }

--- a/src/containers/apps/oneclick/OneClickDeploymentConstants.ts
+++ b/src/containers/apps/oneclick/OneClickDeploymentConstants.ts
@@ -1,0 +1,4 @@
+export const DEPLOYMENT_QUERY_PARAM_TEMPLATE = 'template'
+export const DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY = 'valuesArray'
+export const DEPLOYMENT_QUERY_PARAM_APP_NAME = 'appName'
+export const DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME = 'templateName'

--- a/src/containers/apps/oneclick/selector/OneClickAppSelector.tsx
+++ b/src/containers/apps/oneclick/selector/OneClickAppSelector.tsx
@@ -65,7 +65,7 @@ export default class OneClickAppSelector extends ApiComponent<
                     if (appName === TEMPLATE_ONE_CLICK_APP) {
                         event.preventDefault()
                         self.props.history.push(
-                            `/apps/oneclick/input/${TEMPLATE_ONE_CLICK_APP}`
+                            `/apps/oneclick/templategenerator`
                         )
                     }
                 }}

--- a/src/containers/apps/oneclick/selector/OneClickGrid.tsx
+++ b/src/containers/apps/oneclick/selector/OneClickGrid.tsx
@@ -10,6 +10,23 @@ import { IHashMapGeneric } from '../../../../models/IHashMapGeneric'
 import { IOneClickAppIdentifier } from '../../../../models/IOneClickAppModels'
 import StringSimilarity from '../../../../utils/StringSimilarity'
 import NewTabLink from '../../../global/NewTabLink'
+import { DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME } from '../OneClickDeploymentConstants'
+
+const MAIN_ONE_CLICK_APP_REPOSITORY = 'https://oneclickapps.caprover.com'
+
+function isMainOneClickAppRepository(baseUrl: string) {
+    try {
+        const repositoryUrl = new URL(baseUrl)
+        return (
+            repositoryUrl.origin === MAIN_ONE_CLICK_APP_REPOSITORY &&
+            (repositoryUrl.pathname === '' || repositoryUrl.pathname === '/') &&
+            !repositoryUrl.search &&
+            !repositoryUrl.hash
+        )
+    } catch {
+        return false
+    }
+}
 
 export default class OneClickGrid extends Component<
     {
@@ -30,9 +47,8 @@ export default class OneClickGrid extends Component<
     }
 
     create3rdPartyTagIfNeeded(app: IOneClickAppIdentifier) {
-        const MAIN_REPO = `https://oneclickapps.caprover.com`
-
-        const isFromMainRepository = app.baseUrl === MAIN_REPO || !app.baseUrl
+        const isFromMainRepository =
+            isMainOneClickAppRepository(app.baseUrl) || !app.baseUrl
         const isUsingOfficialImage = !!app.isOfficial
 
         return (
@@ -62,7 +78,8 @@ export default class OneClickGrid extends Component<
             app.name && app.baseUrl
                 ? `/apps/oneclick/${app.name}?baseDomain=${encodeURIComponent(
                       app.baseUrl
-                  )}`
+                  )}` +
+                  `&${DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME}=${isMainOneClickAppRepository(app.baseUrl) ? 'OFFICIAL_' + app.name : 'PRIVATE'}`
                 : '#'
         return (
             <div key={app.name + app.baseUrl} className="one-click-app-card">

--- a/src/containers/apps/oneclick/template/TemplateInputPage.tsx
+++ b/src/containers/apps/oneclick/template/TemplateInputPage.tsx
@@ -4,6 +4,7 @@ import { localize } from '../../../../utils/Language'
 import ApiComponent from '../../../global/ApiComponent'
 import InputJsonifier from '../../../global/InputJsonifier'
 import NewTabLink from '../../../global/NewTabLink'
+import { DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME } from '../OneClickDeploymentConstants'
 import { TEMPLATE_ONE_CLICK_APP } from '../selector/OneClickAppSelector'
 
 export const ONE_CLICK_APP_STRINGIFIED_KEY = 'oneClickAppStringifiedData'
@@ -100,7 +101,8 @@ caproverOneClickApp:
                                 `/apps/oneclick/${TEMPLATE_ONE_CLICK_APP}?${ONE_CLICK_APP_STRINGIFIED_KEY}=` +
                                     encodeURIComponent(
                                         self.state.templateOneClickAppData
-                                    )
+                                    ) +
+                                    `&${DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME}=TEMPLATE_ONE_CLICK`
                             )
                         }
                         disabled={

--- a/src/containers/apps/oneclick/variables/OneClickAppConfigPage.tsx
+++ b/src/containers/apps/oneclick/variables/OneClickAppConfigPage.tsx
@@ -9,6 +9,12 @@ import Utils from '../../../../utils/Utils'
 import ApiComponent from '../../../global/ApiComponent'
 import CenteredSpinner from '../../../global/CenteredSpinner'
 import {
+    DEPLOYMENT_QUERY_PARAM_APP_NAME,
+    DEPLOYMENT_QUERY_PARAM_TEMPLATE,
+    DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME,
+    DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
+} from '../OneClickDeploymentConstants'
+import {
     ONE_CLICK_APP_STRINGIFIED_KEY,
     TEMPLATE_ONE_CLICK_APP,
 } from '../selector/OneClickAppSelector'
@@ -16,11 +22,6 @@ import OneClickVariablesSection from './OneClickVariablesSection'
 
 export const ONE_CLICK_APP_NAME_VAR_NAME = '$$cap_appname'
 export const ONE_CLICK_ROOT_DOMAIN_VAR_NAME = '$$cap_root_domain'
-
-// Query parameter constants for deployment page
-export const DEPLOYMENT_QUERY_PARAM_TEMPLATE = 'template'
-export const DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY = 'valuesArray'
-export const DEPLOYMENT_QUERY_PARAM_APP_NAME = 'appName'
 
 export default class OneClickAppConfigPage extends ApiComponent<
     RouteComponentProps<any>,
@@ -186,7 +187,14 @@ export default class OneClickAppConfigPage extends ApiComponent<
                                         self.props.match.params.appName
                                     )
 
-                                    const deployUrl = `/apps/oneclick/deployment?${DEPLOYMENT_QUERY_PARAM_TEMPLATE}=${templateStr}&${DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY}=${valuesArrayStr}&${DEPLOYMENT_QUERY_PARAM_APP_NAME}=${appName}`
+                                    const templateName =
+                                        new URLSearchParams(
+                                            self.props.location.search
+                                        ).get(
+                                            DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME
+                                        ) || ''
+
+                                    const deployUrl = `/apps/oneclick/deployment?${DEPLOYMENT_QUERY_PARAM_TEMPLATE}=${templateStr}&${DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY}=${valuesArrayStr}&${DEPLOYMENT_QUERY_PARAM_APP_NAME}=${appName}&${DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME}=${templateName}`
                                     self.props.history.push(deployUrl)
                                 }}
                             />

--- a/src/containers/apps/oneclick/variables/OneClickDeploymentPage.tsx
+++ b/src/containers/apps/oneclick/variables/OneClickDeploymentPage.tsx
@@ -7,8 +7,9 @@ import CenteredSpinner from '../../../global/CenteredSpinner'
 import {
     DEPLOYMENT_QUERY_PARAM_APP_NAME,
     DEPLOYMENT_QUERY_PARAM_TEMPLATE,
+    DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME,
     DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY,
-} from './OneClickAppConfigPage'
+} from '../OneClickDeploymentConstants'
 import OneClickAppDeployProgress from './OneClickAppDeployProgress'
 
 export default class OneClickDeploymentPage extends ApiComponent<
@@ -45,8 +46,9 @@ export default class OneClickDeploymentPage extends ApiComponent<
         const templateStr = qs.get(DEPLOYMENT_QUERY_PARAM_TEMPLATE)
         const valuesArrayStr = qs.get(DEPLOYMENT_QUERY_PARAM_VALUES_ARRAY)
         const appName = qs.get(DEPLOYMENT_QUERY_PARAM_APP_NAME) || ''
+        const templateName = qs.get(DEPLOYMENT_QUERY_PARAM_TEMPLATE_NAME) || ''
 
-        if (!templateStr || !valuesArrayStr || !appName) {
+        if (!templateStr || !valuesArrayStr || !appName || !templateName) {
             Toaster.createCatcher()(
                 'Missing required parameters for deployment'
             )
@@ -70,7 +72,7 @@ export default class OneClickDeploymentPage extends ApiComponent<
             // Start deployment immediately
             DomUtils.scrollToTopBar()
             self.apiManager
-                .startOneClickAppDeploy(template, valuesArray)
+                .startOneClickAppDeploy(template, valuesArray, templateName)
                 .then((data: any) => {
                     // store job id and render progress component
                     self.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,10 +3807,10 @@ caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001716:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz#dae13a9c80d517c30c6197515a96131c194d8f82"
   integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
 
-caprover-api@^0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/caprover-api/-/caprover-api-0.0.18.tgz#4fd4f24c0af7bdebafa2fbd1dec5d97c476cd356"
-  integrity sha512-wGkVTUCzqmgl8tRRj4+5H2C5cnVp0t11mfglDTjxnCZzQv2gEmCp40UdVHwFXsJ5qz4Jbm5WchB5nM/8cMNXPA==
+caprover-api@^0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/caprover-api/-/caprover-api-0.0.19.tgz#b48b8d86628e23603fff56eb74c282f786f67205"
+  integrity sha512-r5a+9oq52uMgLuLRQVs783m65dC+Yoex/DPNphiN9/p6HN2KT9Z/T+2Y2ADCBpfLG1MvURe/LI0ee/zYS+cetA==
   dependencies:
     cross-fetch "^4.1.0"
 


### PR DESCRIPTION
## Summary

- attach a template source identifier to official, private, free-form, and Docker Compose deployments
- forward the identifier through the configuration and deployment flow to `caprover-api`
- upgrade `caprover-api` to 0.0.19 for the new deployment argument
- move deployment query parameter names into a shared constants module
- give the free-form template generator a dedicated route
- classify only the canonical One-Click App repository as official

## Why

The backend needs to know which template source initiated a One-Click deployment. Previously the deployment request contained the rendered template and values but no source identifier.

## Impact

Deployments now report one of:

- `OFFICIAL_<app-name>`
- `PRIVATE`
- `TEMPLATE_ONE_CLICK`
- `DOCKER_COMPOSE`

The value is attribution metadata supplied by the client and should not be treated as an authorization or security signal.

## Validation

- `yarn tslint`
- `CI=true yarn test --watchAll=false --runInBand` — 46 tests passed
- `git diff --check`
- confirmed `caprover-api@0.0.19` is installed and the new API call type-checks

A full standalone `tsc --noEmit` still reports existing declaration incompatibilities in third-party dependencies (`@rc-component/qrcode`, Redux Toolkit, `rc-picker`, and `vfile`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template-aware deployment support for One-Click apps and Docker Compose apps.
  * Added clearer routing for template generation and custom template configuration.
  * Added validation to distinguish official and private One-Click repositories.

* **Bug Fixes**
  * Improved deployment URL handling to preserve template information throughout configuration and deployment.
  * Updated the CapRover API integration to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->