### PR TITLE
Fix persisted authentication after page reload

### DIFF
--- a/src/api/ApiManager.test.ts
+++ b/src/api/ApiManager.test.ts
@@ -6,10 +6,7 @@ let mockAuthProvider: TestAuthProvider | undefined
 
 jest.mock('caprover-api', () => {
     return class {
-        constructor(
-            _baseDomain: string,
-            authProvider: TestAuthProvider
-        ) {
+        constructor(_baseDomain: string, authProvider: TestAuthProvider) {
             mockAuthProvider = authProvider
         }
     }

--- a/src/api/ApiManager.test.ts
+++ b/src/api/ApiManager.test.ts
@@ -1,0 +1,31 @@
+describe('ApiManager authentication initialization', () => {
+    beforeEach(() => {
+        jest.resetModules()
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+    })
+
+    it('restores an authentication token from localStorage', () => {
+        const StorageHelper = require('../utils/StorageHelper').default
+        StorageHelper.setAuthKeyInLocalStorage('local-token')
+
+        const ApiManager = require('./ApiManager').default
+
+        expect(ApiManager.isLoggedIn()).toBe(true)
+    })
+
+    it('restores an authentication token from sessionStorage', () => {
+        const StorageHelper = require('../utils/StorageHelper').default
+        StorageHelper.setAuthKeyInSessionStorage('session-token')
+
+        const ApiManager = require('./ApiManager').default
+
+        expect(ApiManager.isLoggedIn()).toBe(true)
+    })
+
+    it('starts logged out when no authentication token is stored', () => {
+        const ApiManager = require('./ApiManager').default
+
+        expect(ApiManager.isLoggedIn()).toBe(false)
+    })
+})

--- a/src/api/ApiManager.test.ts
+++ b/src/api/ApiManager.test.ts
@@ -1,31 +1,64 @@
+type TestAuthProvider = {
+    onAuthTokenRequested: () => Promise<string>
+}
+
+let mockAuthProvider: TestAuthProvider | undefined
+
+jest.mock('caprover-api', () => {
+    return class {
+        constructor(
+            _baseDomain: string,
+            authProvider: TestAuthProvider
+        ) {
+            mockAuthProvider = authProvider
+        }
+    }
+})
+
+const loadApiManager = () => {
+    const ApiManager = require('./ApiManager').default
+    new ApiManager()
+    return ApiManager
+}
+
 describe('ApiManager authentication initialization', () => {
     beforeEach(() => {
         jest.resetModules()
         window.localStorage.clear()
         window.sessionStorage.clear()
+        mockAuthProvider = undefined
     })
 
-    it('restores an authentication token from localStorage', () => {
+    it('restores an authentication token from localStorage', async () => {
         const StorageHelper = require('../utils/StorageHelper').default
         StorageHelper.setAuthKeyInLocalStorage('local-token')
 
-        const ApiManager = require('./ApiManager').default
+        const ApiManager = loadApiManager()
 
         expect(ApiManager.isLoggedIn()).toBe(true)
+        expect(await mockAuthProvider!.onAuthTokenRequested()).toBe(
+            'local-token'
+        )
     })
 
-    it('restores an authentication token from sessionStorage', () => {
+    it('restores an authentication token from sessionStorage', async () => {
         const StorageHelper = require('../utils/StorageHelper').default
         StorageHelper.setAuthKeyInSessionStorage('session-token')
 
-        const ApiManager = require('./ApiManager').default
+        const ApiManager = loadApiManager()
 
         expect(ApiManager.isLoggedIn()).toBe(true)
+        expect(await mockAuthProvider!.onAuthTokenRequested()).toBe(
+            'session-token'
+        )
     })
 
-    it('starts logged out when no authentication token is stored', () => {
-        const ApiManager = require('./ApiManager').default
+    it('starts logged out when no authentication token is stored', async () => {
+        const ApiManager = loadApiManager()
 
         expect(ApiManager.isLoggedIn()).toBe(false)
+        expect(await mockAuthProvider!.onAuthTokenRequested()).toBe('')
     })
 })
+
+export {}

--- a/src/api/ApiManager.ts
+++ b/src/api/ApiManager.ts
@@ -9,7 +9,7 @@ const URL = BASE_DOMAIN
 Logger.dev(`API URL: ${URL}`)
 
 const authProvider = {
-    authToken: '' as string,
+    authToken: StorageHelper.getAuthKeyFromStorage(),
     hadEnteredOtp: false as boolean,
     lastKnownPassword: '' as string,
     onAuthTokenRequested: () => {


### PR DESCRIPTION
## What changed

- Restore the authentication token from browser storage when the frontend initializes
- Add regression coverage for localStorage, sessionStorage, and the no-token case

## Root cause

The migration to the `caprover-api` package changed the in-memory authentication provider to always start with an empty token. A page reload therefore treated persisted sessions as logged out, and the unauthorized flow could clear the valid stored token.

## Impact

The "Use localStorage" and "Use sessionStorage" login options now survive reloads as intended. "No session persistence" remains unchanged, and invalid stored tokens are still cleared by the existing authentication failure flow.

Fixes https://github.com/caprover/caprover/issues/2456

## Validation

- Added focused module-initialization regression tests for both persistence modes and the logged-out case
- Inspected the remote commit diff
- CI checks will run on this pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored authentication tokens from browser storage during app initialization, keeping users signed in across sessions.
  * Correctly starts the app in a logged-out state when no stored token is available.

* **Tests**
  * Added coverage for token restoration from local and session storage, as well as logged-out initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->